### PR TITLE
fix(build): pin asupersync and include lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "asupersync"
-version = "0.2.7"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c42e88ddb3677b6ea2446aab13a91ca91090c6a33ef2e2ed380d3a077e82157"
+checksum = "08c7d8c72c8d8a870a9e5a85a57b04d4e8d15d4be238a0a5818e8c87be2a89da"
 dependencies = [
  "base64 0.22.1",
  "bincode-next",
@@ -309,11 +309,9 @@ dependencies = [
  "franken-decision",
  "franken-evidence",
  "franken-kernel",
- "futures-lite",
  "getrandom 0.4.2",
  "hmac",
  "libc",
- "memchr",
  "nix",
  "parking_lot",
  "pin-project",
@@ -329,7 +327,6 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
- "signal-hook 0.3.18",
  "slab",
  "smallvec",
  "socket2",
@@ -2186,19 +2183,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2434,12 +2418,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4984,12 +4966,6 @@ checksum = "e96cbd21255b7fb29a5d51ef38a779b517a91abd59e2756c039583f43ef4c90f"
 dependencies = [
  "once_cell",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"

--- a/apps/desktop-ui/src/components/sprite/SpriteAnimation.tsx
+++ b/apps/desktop-ui/src/components/sprite/SpriteAnimation.tsx
@@ -15,13 +15,12 @@ interface SpriteAnimationProps {
 }
 
 // Sprite sheet configuration
-// sprite.png is 1024x896 (8 cols × 7 rows = 128×128 per frame)
 const SPRITE_CONFIG = {
   columns: 8,
   rows: 7,
   frameWidth: 128,
   frameHeight: 128,
-  imageSrc: "/sprite.png",
+  imageSrc: "/sprite.jpg",
 };
 
 // Animation row mapping (matches new sprite sheet layout)

--- a/crates/peekoo-agent-app/Cargo.toml
+++ b/crates/peekoo-agent-app/Cargo.toml
@@ -9,7 +9,7 @@ peekoo-agent-auth = { path = "../peekoo-agent-auth" }
 peekoo-productivity-domain = { path = "../peekoo-productivity-domain" }
 peekoo-persistence-sqlite = { path = "../persistence-sqlite" }
 peekoo-security = { path = "../security" }
-asupersync = "0.2"
+asupersync = "=0.2.5"
 rusqlite = { version = "0.38" }
 dirs = "6"
 uuid = { version = "1", features = ["v4"] }

--- a/crates/peekoo-agent/Cargo.toml
+++ b/crates/peekoo-agent/Cargo.toml
@@ -8,4 +8,4 @@ dirs = "6.0.0"
 pi = { version = "0.1.7", package = "pi_agent_rust" }
 
 [dev-dependencies]
-asupersync = "0.2"
+asupersync = "=0.2.5"


### PR DESCRIPTION
Pin asupersync to =0.2.5 in crates that depend on pi_agent_rust 0.1.7 to avoid receiver mutability compile errors introduced by newer asupersync releases. Update Cargo.lock accordingly.

Also switch sprite asset source back to /sprite.jpg.

https://github.com/feed-mob/tracking_admin/issues/21899