### PR TITLE
fix(desktop-tauri): set writable WebView2 data dir on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5060,6 +5060,7 @@ dependencies = [
 name = "peekoo-desktop-tauri"
 version = "0.1.0"
 dependencies = [
+ "dirs",
  "peekoo-agent-app",
  "serde",
  "serde_json",

--- a/apps/desktop-tauri/src-tauri/Cargo.toml
+++ b/apps/desktop-tauri/src-tauri/Cargo.toml
@@ -19,3 +19,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 peekoo-agent-app = { path = "../../../crates/peekoo-agent-app" }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+dirs = "6"

--- a/apps/desktop-tauri/src-tauri/src/lib.rs
+++ b/apps/desktop-tauri/src-tauri/src/lib.rs
@@ -204,6 +204,25 @@ async fn pomodoro_finish(
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // On Windows, WebView2 defaults to writing its data next to the executable,
+    // which is typically inside Program Files and not writable. Set an explicit
+    // user-writable path before Tauri initialises the webview.
+    #[cfg(target_os = "windows")]
+    {
+        if std::env::var("WEBVIEW2_USER_DATA_FOLDER").is_err() {
+            if let Some(mut data_dir) = dirs::data_local_dir() {
+                data_dir.push("com.peekoo.desktop");
+                data_dir.push("WebView2");
+                if let Err(e) = std::fs::create_dir_all(&data_dir) {
+                    eprintln!("warning: failed to create WebView2 data dir: {e}");
+                }
+                // SAFETY: Called at the start of `run()` before `tauri::Builder`
+                // is constructed, so no other threads are running yet.
+                unsafe { std::env::set_var("WEBVIEW2_USER_DATA_FOLDER", data_dir) };
+            }
+        }
+    }
+
     let agent_state = AgentState::new();
 
     tauri::Builder::default()


### PR DESCRIPTION
On Windows, WebView2 fails to start when its default data directory is not writable (e.g. inside Program Files or with certain user account configurations). Explicitly set WEBVIEW2_USER_DATA_FOLDER to LocalAppData before Tauri initialises.