### PR TITLE
fix(desktop-tauri): set explicit webview data directory

### DIFF
--- a/apps/desktop-tauri/src-tauri/tauri.conf.json
+++ b/apps/desktop-tauri/src-tauri/tauri.conf.json
@@ -23,7 +23,8 @@
         "decorations": false,
         "transparent": true,
         "alwaysOnTop": true,
-        "skipTaskbar": true
+        "skipTaskbar": true,
+        "dataDirectory": "webview-data"
       }
     ],
     "security": {


### PR DESCRIPTION
Configure Tauri window dataDirectory so WebView2 uses a stable app-local subdirectory instead of the default EBWebView path.