### PR TITLE
fix(paths): use platform-aware paths for Windows compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5013,7 +5013,7 @@ name = "peekoo-agent"
 version = "0.1.0"
 dependencies = [
  "asupersync",
- "dirs",
+ "peekoo-paths",
  "pi_agent_rust",
 ]
 
@@ -5022,9 +5022,9 @@ name = "peekoo-agent-app"
 version = "0.1.0"
 dependencies = [
  "asupersync",
- "dirs",
  "peekoo-agent",
  "peekoo-agent-auth",
+ "peekoo-paths",
  "peekoo-persistence-sqlite",
  "peekoo-productivity-domain",
  "peekoo-security",
@@ -5076,6 +5076,13 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "peekoo-paths"
+version = "0.1.0"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "crates/peekoo-agent",
   "crates/peekoo-agent-auth",
   "crates/peekoo-agent-app",
+  "crates/peekoo-paths",
   "apps/desktop-tauri/src-tauri",
 ]
 resolver = "2"

--- a/crates/peekoo-agent-app/Cargo.toml
+++ b/crates/peekoo-agent-app/Cargo.toml
@@ -9,9 +9,9 @@ peekoo-agent-auth = { path = "../peekoo-agent-auth" }
 peekoo-productivity-domain = { path = "../peekoo-productivity-domain" }
 peekoo-persistence-sqlite = { path = "../persistence-sqlite" }
 peekoo-security = { path = "../security" }
+peekoo-paths = { path = "../peekoo-paths" }
 asupersync = "=0.2.5"
 rusqlite = { version = "0.38" }
-dirs = "6"
 uuid = { version = "1", features = ["v4"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/peekoo-agent-app/src/application.rs
+++ b/crates/peekoo-agent-app/src/application.rs
@@ -3,6 +3,7 @@ use std::sync::Mutex;
 use peekoo_agent::AgentEvent;
 use peekoo_agent::config::AgentServiceConfig;
 use peekoo_agent::service::AgentService;
+use peekoo_paths::ensure_windows_pi_agent_env;
 
 use crate::productivity::{PomodoroSessionDto, ProductivityService, TaskDto};
 use crate::settings::{
@@ -21,6 +22,7 @@ pub struct AgentApplication {
 
 impl AgentApplication {
     pub fn new() -> Result<Self, String> {
+        ensure_windows_pi_agent_env()?;
         Ok(Self {
             agent: Mutex::new(None),
             settings: SettingsService::new()?,

--- a/crates/peekoo-agent-app/src/settings/mod.rs
+++ b/crates/peekoo-agent-app/src/settings/mod.rs
@@ -6,7 +6,7 @@ mod pi_models;
 mod skills;
 mod store;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use peekoo_agent::config::AgentServiceConfig;
 use peekoo_agent_auth::{OAuthFlowStatus, OAuthService};
@@ -37,6 +37,7 @@ pub struct SettingsService {
 impl SettingsService {
     pub fn new() -> Result<Self, String> {
         let db_path = default_db_path()?;
+        migrate_legacy_settings_db_if_needed(&db_path)?;
         let store = SettingsStore::from_path(&db_path)?;
         Ok(Self {
             store,
@@ -246,8 +247,78 @@ fn secret_error(err: SecretStoreError) -> String {
 }
 
 fn default_db_path() -> Result<PathBuf, String> {
-    let Some(home) = dirs::home_dir() else {
-        return Err("Cannot determine home directory".into());
+    peekoo_paths::peekoo_settings_db_path()
+}
+
+fn migrate_legacy_settings_db_if_needed(target_db_path: &Path) -> Result<(), String> {
+    migrate_settings_db_if_needed(target_db_path, peekoo_paths::peekoo_legacy_home_dir())
+}
+
+fn migrate_settings_db_if_needed(
+    target_db_path: &Path,
+    legacy_root: Option<PathBuf>,
+) -> Result<(), String> {
+    if target_db_path.exists() {
+        return Ok(());
+    }
+
+    let Some(legacy_root) = legacy_root else {
+        return Ok(());
     };
-    Ok(home.join(".peekoo").join("peekoo.sqlite"))
+    let legacy_db_path = legacy_root.join("peekoo.sqlite");
+    if !legacy_db_path.is_file() {
+        return Ok(());
+    }
+
+    if let Some(parent) = target_db_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Create settings db dir error ({}): {e}", parent.display()))?;
+    }
+
+    std::fs::copy(&legacy_db_path, target_db_path).map_err(|e| {
+        format!(
+            "Migrate settings db error ({} -> {}): {e}",
+            legacy_db_path.display(),
+            target_db_path.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_db_path_uses_shared_paths_crate() {
+        let expected = peekoo_paths::peekoo_settings_db_path().expect("shared db path");
+        let actual = default_db_path().expect("settings db path");
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn migration_copies_legacy_db_when_target_missing() {
+        let temp = std::env::temp_dir().join(format!(
+            "peekoo-settings-migration-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let legacy_root = temp.join("legacy");
+        let target_root = temp.join("target");
+        std::fs::create_dir_all(&legacy_root).expect("create legacy root");
+        std::fs::create_dir_all(&target_root).expect("create target root");
+
+        let legacy_db = legacy_root.join("peekoo.sqlite");
+        std::fs::write(&legacy_db, b"legacy-db").expect("write legacy db");
+        let target_db = target_root.join("peekoo.sqlite");
+
+        migrate_settings_db_if_needed(&target_db, Some(legacy_root)).expect("migrate db");
+        let copied = std::fs::read(&target_db).expect("read copied db");
+        assert_eq!(copied, b"legacy-db");
+
+        let _ = std::fs::remove_dir_all(&temp);
+    }
 }

--- a/crates/peekoo-agent-app/src/settings/pi_models.rs
+++ b/crates/peekoo-agent-app/src/settings/pi_models.rs
@@ -1,17 +1,19 @@
 use crate::settings::dto::ProviderConfigDto;
 
 pub fn ensure_pi_models_provider(cfg: &ProviderConfigDto, model_id: &str) -> Result<(), String> {
-    let Some(home) = dirs::home_dir() else {
-        return Err("Cannot determine home directory".into());
+    let models_path = peekoo_paths::pi_models_path()?;
+    let Some(parent) = models_path.parent() else {
+        return Err(format!("Invalid pi models path: {}", models_path.display()));
     };
-    let pi_dir = home.join(".pi");
-    std::fs::create_dir_all(&pi_dir).map_err(|e| format!("Create ~/.pi dir error: {e}"))?;
-    let models_path = pi_dir.join("models.json");
+    std::fs::create_dir_all(parent)
+        .map_err(|e| format!("Create pi models dir error ({}): {e}", parent.display()))?;
+    migrate_legacy_models_if_needed(&models_path)?;
 
     let mut root: serde_json::Value = if models_path.is_file() {
         let content = std::fs::read_to_string(&models_path)
-            .map_err(|e| format!("Read ~/.pi/models.json error: {e}"))?;
-        serde_json::from_str(&content).map_err(|e| format!("Parse ~/.pi/models.json error: {e}"))?
+            .map_err(|e| format!("Read pi models error ({}): {e}", models_path.display()))?;
+        serde_json::from_str(&content)
+            .map_err(|e| format!("Parse pi models error ({}): {e}", models_path.display()))?
     } else {
         serde_json::json!({ "providers": {} })
     };
@@ -45,8 +47,85 @@ pub fn ensure_pi_models_provider(cfg: &ProviderConfigDto, model_id: &str) -> Res
     );
 
     let serialized = serde_json::to_string_pretty(&root)
-        .map_err(|e| format!("Serialize ~/.pi/models.json error: {e}"))?;
+        .map_err(|e| format!("Serialize pi models error ({}): {e}", models_path.display()))?;
     std::fs::write(&models_path, serialized)
-        .map_err(|e| format!("Write ~/.pi/models.json error: {e}"))?;
+        .map_err(|e| format!("Write pi models error ({}): {e}", models_path.display()))?;
     Ok(())
+}
+
+fn migrate_legacy_models_if_needed(models_path: &std::path::Path) -> Result<(), String> {
+    if models_path.exists() {
+        return Ok(());
+    }
+
+    let legacy_candidates = peekoo_paths::pi_legacy_models_paths();
+    let Some(source) = legacy_candidates.iter().find(|path| path.is_file()) else {
+        return Ok(());
+    };
+
+    std::fs::copy(source, models_path).map_err(|e| {
+        format!(
+            "Migrate pi models error ({} -> {}): {e}",
+            source.display(),
+            models_path.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn ensure_provider_writes_to_pi_agent_dir_override() {
+        let _guard = env_lock().lock().expect("env lock");
+
+        let original = std::env::var_os("PI_CODING_AGENT_DIR");
+        let test_dir = std::env::temp_dir().join(format!(
+            "peekoo-pi-models-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+
+        // SAFETY: test is serialized via mutex and restores env before returning.
+        unsafe { std::env::set_var("PI_CODING_AGENT_DIR", &test_dir) };
+
+        let cfg = ProviderConfigDto {
+            provider_id: "openai-compatible".to_string(),
+            base_url: "https://example.com/v1".to_string(),
+            api: "openai-completions".to_string(),
+            auth_header: true,
+        };
+
+        ensure_pi_models_provider(&cfg, "gpt-test").expect("write models");
+
+        let models_path = test_dir.join("models.json");
+        assert!(models_path.is_file());
+
+        let content = std::fs::read_to_string(models_path).expect("read models");
+        assert!(content.contains("openai-compatible"));
+        assert!(content.contains("gpt-test"));
+
+        let _ = std::fs::remove_dir_all(&test_dir);
+        match original {
+            Some(value) => {
+                // SAFETY: restoring env state after test.
+                unsafe { std::env::set_var("PI_CODING_AGENT_DIR", value) };
+            }
+            None => {
+                // SAFETY: restoring env state after test.
+                unsafe { std::env::remove_var("PI_CODING_AGENT_DIR") };
+            }
+        }
+    }
 }

--- a/crates/peekoo-agent-app/src/settings/skills.rs
+++ b/crates/peekoo-agent-app/src/settings/skills.rs
@@ -23,8 +23,12 @@ pub fn discover_skills() -> Vec<SkillDto> {
         }
     }
 
-    if let Some(home) = dirs::home_dir() {
-        roots.push(home.join(".peekoo").join("skills"));
+    if let Ok(global_skills_dir) = peekoo_paths::peekoo_global_skills_dir() {
+        roots.push(global_skills_dir);
+    }
+
+    if let Some(legacy_home) = peekoo_paths::peekoo_legacy_home_dir_if_distinct() {
+        roots.push(legacy_home.join("skills"));
     }
 
     for root in roots {

--- a/crates/peekoo-agent/Cargo.toml
+++ b/crates/peekoo-agent/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-dirs = "6.0.0"
+peekoo-paths = { path = "../peekoo-paths" }
 pi = { version = "0.1.7", package = "pi_agent_rust" }
 
 [dev-dependencies]

--- a/crates/peekoo-agent/src/config.rs
+++ b/crates/peekoo-agent/src/config.rs
@@ -49,7 +49,8 @@ pub struct AgentServiceConfig {
     pub agent_skills: Vec<PathBuf>,
 
     /// Automatically discover persona files and skills from a `.peekoo/` directory
-    /// in the `working_directory`, falling back to `~/.peekoo/`.
+    /// in the `working_directory`, falling back to the platform global Peekoo
+    /// config directory (legacy `~/.peekoo/` is still checked for compatibility).
     /// Discovered paths are used *only* if `persona_dir` and `agent_skills`
     /// aren't explicitly provided.
     pub auto_discover: bool,

--- a/crates/peekoo-agent/src/service.rs
+++ b/crates/peekoo-agent/src/service.rs
@@ -59,9 +59,12 @@ impl AgentService {
             // 2. Next: Local working directory (crawled up to workspace root)
             search_paths.push(config.working_directory.join(".peekoo"));
 
-            // 3. Last fallback: Global ~/.peekoo
-            if let Some(home) = dirs::home_dir() {
-                search_paths.push(home.join(".peekoo"));
+            // 3. Last fallback: global peekoo config dir, then legacy ~/.peekoo
+            if let Ok(global_dir) = peekoo_paths::peekoo_global_config_dir() {
+                search_paths.push(global_dir);
+            }
+            if let Some(legacy_home) = peekoo_paths::peekoo_legacy_home_dir_if_distinct() {
+                search_paths.push(legacy_home);
             }
 
             for path in search_paths {

--- a/crates/peekoo-paths/Cargo.toml
+++ b/crates/peekoo-paths/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "peekoo-paths"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+dirs = "6"

--- a/crates/peekoo-paths/src/lib.rs
+++ b/crates/peekoo-paths/src/lib.rs
@@ -1,0 +1,187 @@
+use std::path::PathBuf;
+
+pub fn peekoo_global_config_dir() -> Result<PathBuf, String> {
+    if cfg!(target_os = "windows") {
+        let base =
+            dirs::config_dir().ok_or_else(|| "Cannot determine config directory".to_string())?;
+        return Ok(base.join("Peekoo").join("peekoo"));
+    }
+
+    let home = dirs::home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
+    Ok(home.join(".peekoo"))
+}
+
+pub fn peekoo_global_data_dir() -> Result<PathBuf, String> {
+    if cfg!(target_os = "windows") {
+        let base = dirs::data_local_dir()
+            .ok_or_else(|| "Cannot determine local data directory".to_string())?;
+        return Ok(base.join("Peekoo").join("peekoo"));
+    }
+
+    let home = dirs::home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
+    Ok(home.join(".peekoo"))
+}
+
+pub fn peekoo_legacy_home_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".peekoo"))
+}
+
+/// Returns the legacy home dir only when it differs from the current
+/// `peekoo_global_config_dir()`. On non-Windows this returns `None`
+/// because both resolve to `~/.peekoo`, avoiding duplicate directory scans.
+pub fn peekoo_legacy_home_dir_if_distinct() -> Option<PathBuf> {
+    let legacy = peekoo_legacy_home_dir()?;
+    let primary = peekoo_global_config_dir().ok()?;
+    if legacy == primary {
+        None
+    } else {
+        Some(legacy)
+    }
+}
+
+/// Returns legacy candidate paths for pi `models.json` that existed before
+/// the platform-aware migration. Used for copy-if-missing migration only.
+pub fn pi_legacy_models_paths() -> Vec<PathBuf> {
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+    vec![
+        home.join(".pi").join("models.json"),
+        home.join(".pi").join("agent").join("models.json"),
+    ]
+}
+
+pub fn peekoo_settings_db_path() -> Result<PathBuf, String> {
+    Ok(peekoo_global_data_dir()?.join("peekoo.sqlite"))
+}
+
+pub fn peekoo_global_skills_dir() -> Result<PathBuf, String> {
+    Ok(peekoo_global_config_dir()?.join("skills"))
+}
+
+pub fn pi_agent_dir() -> Result<PathBuf, String> {
+    if let Some(override_dir) = std::env::var_os("PI_CODING_AGENT_DIR") {
+        return Ok(PathBuf::from(override_dir));
+    }
+
+    if cfg!(target_os = "windows") {
+        let base = dirs::data_local_dir()
+            .ok_or_else(|| "Cannot determine local data directory".to_string())?;
+        return Ok(base.join("Peekoo").join("pi").join("agent"));
+    }
+
+    let home = dirs::home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
+    Ok(home.join(".pi").join("agent"))
+}
+
+pub fn pi_models_path() -> Result<PathBuf, String> {
+    Ok(pi_agent_dir()?.join("models.json"))
+}
+
+pub fn ensure_windows_pi_agent_env() -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        if std::env::var_os("PI_CODING_AGENT_DIR").is_none() {
+            let dir = pi_agent_dir()?;
+            // SAFETY: called by app bootstrap on startup before threads are spawned.
+            unsafe { std::env::set_var("PI_CODING_AGENT_DIR", dir) };
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn pi_models_path_is_under_pi_agent_dir() {
+        let dir = pi_agent_dir().expect("pi agent dir");
+        let models = pi_models_path().expect("pi models path");
+        assert_eq!(models, dir.join("models.json"));
+    }
+
+    #[test]
+    fn peekoo_skills_path_is_under_config_dir() {
+        let cfg = peekoo_global_config_dir().expect("peekoo config dir");
+        let skills = peekoo_global_skills_dir().expect("peekoo skills dir");
+        assert_eq!(skills, cfg.join("skills"));
+    }
+
+    #[test]
+    fn settings_db_path_is_inside_data_dir() {
+        let data = peekoo_global_data_dir().expect("peekoo data dir");
+        let db = peekoo_settings_db_path().expect("peekoo settings db path");
+        assert_eq!(db, data.join("peekoo.sqlite"));
+    }
+
+    #[test]
+    fn legacy_home_dir_points_to_dot_peekoo() {
+        if let Some(path) = peekoo_legacy_home_dir() {
+            assert_eq!(path.file_name(), Some(std::ffi::OsStr::new(".peekoo")));
+        }
+    }
+
+    #[test]
+    fn windows_pi_env_function_is_safe_to_call() {
+        let result = ensure_windows_pi_agent_env();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn pi_agent_dir_honors_env_override() {
+        let original = std::env::var_os("PI_CODING_AGENT_DIR");
+        let expected = std::env::temp_dir().join("peekoo-paths-env-override");
+
+        // SAFETY: test process controls env access for this assertion.
+        unsafe { std::env::set_var("PI_CODING_AGENT_DIR", &expected) };
+        let resolved = pi_agent_dir().expect("pi agent dir with override");
+        assert_eq!(resolved, expected);
+
+        match original {
+            Some(value) => {
+                // SAFETY: restoring original env var value for test isolation.
+                unsafe { std::env::set_var("PI_CODING_AGENT_DIR", value) };
+            }
+            None => {
+                // SAFETY: restoring env state for test isolation.
+                unsafe { std::env::remove_var("PI_CODING_AGENT_DIR") };
+            }
+        }
+    }
+
+    #[test]
+    fn legacy_home_dir_if_distinct_returns_none_when_same_as_primary() {
+        if cfg!(windows) {
+            // On Windows they should differ, so legacy_if_distinct returns Some.
+            assert!(peekoo_legacy_home_dir_if_distinct().is_some());
+            return;
+        }
+        // On non-Windows both resolve to ~/.peekoo, so should be None.
+        assert!(peekoo_legacy_home_dir_if_distinct().is_none());
+    }
+
+    #[test]
+    fn pi_legacy_models_paths_returns_two_candidates() {
+        let paths = pi_legacy_models_paths();
+        // If we can resolve home_dir, expect 2 candidates; otherwise 0.
+        if dirs::home_dir().is_some() {
+            assert_eq!(paths.len(), 2);
+            assert!(paths[0].ends_with(PathBuf::from(".pi").join("models.json")));
+            assert!(paths[1].ends_with(PathBuf::from(".pi").join("agent").join("models.json")));
+        } else {
+            assert!(paths.is_empty());
+        }
+    }
+
+    #[test]
+    fn non_windows_pi_default_contains_dot_pi_agent() {
+        if cfg!(windows) {
+            return;
+        }
+        let dir = pi_agent_dir().expect("pi agent dir");
+        assert!(dir.to_string_lossy().contains(".pi"));
+        assert!(dir.ends_with(PathBuf::from(".pi").join("agent")));
+    }
+}


### PR DESCRIPTION
Add peekoo-paths crate to centralize path resolution across platforms. On Windows, use AppData directories instead of home dot-folders which can fail with Access Denied errors. Migrate legacy paths non-destructively.

https://github.com/feed-mob/tracking_admin/issues/21835