### PR TITLE
chore(dev): add setup recipe to install cargo-tauri and document it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,9 @@ cd apps/desktop-ui && npx tsc --noEmit
 
 ### Running the Desktop App
 ```bash
+# First-time setup: install frontend deps + cargo-tauri CLI tool
+just setup
+
 # Start dev mode (runs both frontend and Tauri)
 just dev
 ```

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ AI-powered desktop pet built with Tauri v2, React, and Rust. A small, transparen
 ## Getting Started
 
 ```bash
-# Install frontend dependencies
-just install
+# Install all dependencies (frontend + Rust CLI tools like cargo-tauri)
+just setup
 
 # Run in development mode
 just dev
@@ -41,6 +41,9 @@ just dev
 ## Commands
 
 ```bash
+just setup        # Install all dependencies (frontend + Rust tools)
+just install      # Install frontend dependencies only
+just install-tools # Install required Rust CLI tools (cargo-tauri)
 just dev          # Run desktop app in dev mode
 just build        # Production build
 just check        # Check Rust code

--- a/justfile
+++ b/justfile
@@ -12,9 +12,16 @@ build:
 build-appimage:
     cd ./apps/desktop-tauri/src-tauri/ && NO_STRIP=true cargo tauri build --bundles appimage
 
+# Install all dependencies (frontend + Rust tools)
+setup: install install-tools
+
 # Install frontend dependencies with bun
 install:
     cd ./apps/desktop-ui && bun install
+
+# Install required Rust CLI tools
+install-tools:
+    cargo install tauri-cli --version "^2"
 
 # Check Rust code without building
 check:


### PR DESCRIPTION
## Summary
- Add `just setup` recipe that installs frontend deps and cargo-tauri CLI in one step
- Add `just install-tools` recipe for installing cargo-tauri specifically
- Document new recipes in README.md and AGENTS.md

## Why
`just dev` was failing on fresh checkouts because `cargo tauri` (cargo-tauri CLI) was not installed. New contributors had no clear path to get it installed.