### PR TITLE
fix(plugins): treat discovered plugins as installed regardless of load status

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/lib.rs
+++ b/apps/desktop-tauri/src-tauri/src/lib.rs
@@ -287,9 +287,7 @@ async fn plugin_dispatch_event(
 }
 
 #[tauri::command]
-async fn plugin_store_catalog(
-    state: State<'_, AgentState>,
-) -> Result<Vec<StorePluginDto>, String> {
+async fn plugin_store_catalog(state: State<'_, AgentState>) -> Result<Vec<StorePluginDto>, String> {
     state.app.store_catalog()
 }
 

--- a/apps/desktop-ui/src/components/panels/PanelShell.tsx
+++ b/apps/desktop-ui/src/components/panels/PanelShell.tsx
@@ -37,7 +37,7 @@ export function PanelShell({ title, children }: PanelShellProps) {
       </div>
 
       {/* Panel content */}
-      <div className="flex-1 p-panel-padding overflow-y-auto">{children}</div>
+      <div className="flex-1 min-w-0 p-panel-padding overflow-y-auto overflow-x-hidden">{children}</div>
     </div>
   );
 }

--- a/apps/desktop-ui/src/components/sprite/SpriteActionMenu.tsx
+++ b/apps/desktop-ui/src/components/sprite/SpriteActionMenu.tsx
@@ -1,12 +1,13 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { MessageSquare, CheckSquare, Timer, HeartPulse, Puzzle, Blocks } from "lucide-react";
 import type { PanelLabel } from "@/types/window";
 import type { PanelWindowStates } from "@/hooks/use-panel-windows";
 import type { LucideIcon } from "lucide-react";
-import type { PluginPanel } from "@/types/plugin";
+import type { PluginPanel, PluginSummary } from "@/types/plugin";
 import { cn } from "@/lib/utils";
 import { getSpriteActionMenuItems } from "./spriteActionMenuLayout";
+import { computePluginsPopupPosition } from "./spriteActionMenuPopupPosition";
 
 interface MenuItemConfig {
   label: PanelLabel;
@@ -15,6 +16,16 @@ interface MenuItemConfig {
   x: number;
   y: number;
 }
+
+const PLUGINS_POPUP_TAIL_SIZE = 12;
+const PLUGINS_POPUP_TAIL_PADDING = 16;
+
+/**
+ * Vertical offset (px) from the container center to the popup's bottom edge.
+ * The action-menu buttons sit at ROW_Y = 72 and are 38px tall, so their top
+ * is at roughly y = 53.  We add a small gap.
+ */
+const POPUP_BOTTOM_OFFSET = 46;
 
 function iconForPluginPanel(panel: PluginPanel): LucideIcon {
   if (panel.pluginKey === "health-reminders") {
@@ -28,6 +39,7 @@ interface SpriteActionMenuProps {
   onTogglePanel: (label: PanelLabel) => void;
   isOpen: boolean;
   pluginPanels?: PluginPanel[];
+  installedPlugins?: PluginSummary[];
 }
 
 export function SpriteActionMenu({
@@ -35,6 +47,7 @@ export function SpriteActionMenu({
   onTogglePanel,
   isOpen,
   pluginPanels = [],
+  installedPlugins = [],
 }: SpriteActionMenuProps) {
   const [pluginsPopupOpen, setPluginsPopupOpen] = useState(false);
 
@@ -58,11 +71,118 @@ export function SpriteActionMenu({
 
   const pluginsItem = items.find((item) => item.label === "panel-plugins");
 
+  // Compute the tail position.  The plugins button's x offset from center
+  // is known from the layout.  Since the popup is always CSS-centered, we
+  // only need the tail's horizontal offset within the popup.
+  const tailOffsetX = useMemo(() => {
+    if (!pluginsItem) return null;
+    // popup min-width is 180px; actual width may be wider but 180 is our
+    // design target and the tail calculation is stable regardless.
+    const { tailOffsetX: tx } = computePluginsPopupPosition({
+      popupWidth: 180,
+      buttonOffsetX: pluginsItem.x,
+      tailPadding: PLUGINS_POPUP_TAIL_PADDING,
+    });
+    return tx;
+  }, [pluginsItem]);
+
+  const showPopup = isOpen && pluginsPopupOpen && installedPlugins.length > 0;
+
   return (
     <div
       className="absolute inset-0 flex items-center justify-center pointer-events-none"
       onClick={() => setPluginsPopupOpen(false)}
     >
+      {/* ── Plugins popup ─────────────────────────────────────────────── */}
+      {/* Rendered outside the motion.div items so Framer Motion cannot   */}
+      {/* override its CSS transform.  Centering uses flexbox (not       */}
+      {/* transform) so there is nothing for Framer Motion to stomp.     */}
+      <AnimatePresence>
+        {showPopup && (
+            <motion.div
+              key="plugins-popup"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.15 }}
+              className="absolute inset-x-0 flex justify-center z-50 pointer-events-none"
+              style={{ bottom: `calc(50% + ${POPUP_BOTTOM_OFFSET}px)` }}
+            >
+              <div
+                className="relative min-w-[180px] pointer-events-auto"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {/* Tail / arrow */}
+                <div
+                  aria-hidden="true"
+                  className="absolute z-0 rotate-45 bg-glass backdrop-blur-xl border-r border-b border-glass-border"
+                  style={{
+                    width: `${PLUGINS_POPUP_TAIL_SIZE}px`,
+                    height: `${PLUGINS_POPUP_TAIL_SIZE}px`,
+                    left:
+                      tailOffsetX === null
+                        ? `calc(50% - ${PLUGINS_POPUP_TAIL_SIZE / 2}px)`
+                        : `${tailOffsetX - PLUGINS_POPUP_TAIL_SIZE / 2}px`,
+                    bottom: `${-(PLUGINS_POPUP_TAIL_SIZE / 2)}px`,
+                  }}
+                />
+
+                {/* Popup body */}
+                <div className="relative z-10 rounded-lg border border-glass-border bg-glass backdrop-blur-xl shadow-panel p-2">
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setPluginsPopupOpen(false);
+                      onTogglePanel("panel-plugins");
+                    }}
+                    className={cn(
+                      "flex w-full items-center gap-2 px-3 py-2 rounded-md cursor-pointer transition-colors",
+                      panels["panel-plugins"]?.isOpen
+                        ? "bg-space-overlay text-text-primary"
+                        : "text-text-secondary hover:bg-space-overlay hover:text-text-primary",
+                    )}
+                  >
+                    <Blocks size={16} className="shrink-0" />
+                    <span className="text-xs font-medium whitespace-nowrap">Plugins</span>
+                  </button>
+
+                  {installedPlugins.map((plugin) => {
+                    const uiPanel = pluginPanels.find(
+                      (p) => p.pluginKey === plugin.pluginKey,
+                    );
+                    const panelLabel = uiPanel?.label ?? "panel-plugins";
+                    const PanelIcon = uiPanel
+                      ? iconForPluginPanel(uiPanel)
+                      : Puzzle;
+                    const isPanelOpen = panels[panelLabel]?.isOpen;
+
+                    return (
+                      <button
+                        key={plugin.pluginKey}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setPluginsPopupOpen(false);
+                          onTogglePanel(panelLabel);
+                        }}
+                        className={cn(
+                          "flex w-full items-center gap-2 px-3 py-2 rounded-md cursor-pointer transition-colors",
+                          isPanelOpen
+                            ? "bg-space-overlay text-text-primary"
+                            : "text-text-secondary hover:bg-space-overlay hover:text-text-primary",
+                        )}
+                      >
+                        <PanelIcon size={16} className="shrink-0" />
+                        <span className="text-xs font-medium whitespace-nowrap">{plugin.name}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* ── Action menu buttons ───────────────────────────────────────── */}
       <AnimatePresence>
         {isOpen &&
           items.map((item, index) => {
@@ -87,59 +207,6 @@ export function SpriteActionMenu({
                 }}
                 className="absolute"
               >
-                {isPluginsButton && pluginsPopupOpen && pluginsItem && (
-                  <motion.div
-                    initial={{ opacity: 0, y: 8 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: 8 }}
-                    transition={{ duration: 0.15 }}
-                    onClick={(e) => e.stopPropagation()}
-                    className="absolute bottom-full mb-3 left-1/2 -translate-x-1/2 bg-glass border border-glass-border rounded-lg shadow-panel p-2 min-w-[160px] pointer-events-auto"
-                  >
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setPluginsPopupOpen(false);
-                        onTogglePanel("panel-plugins");
-                      }}
-                      className={cn(
-                        "flex w-full items-center gap-2 px-3 py-2 rounded-md cursor-pointer transition-colors",
-                        panels["panel-plugins"]?.isOpen
-                          ? "bg-space-overlay text-text-primary"
-                          : "text-text-secondary hover:bg-space-overlay hover:text-text-primary",
-                      )}
-                    >
-                      <Blocks size={16} />
-                      <span className="text-xs font-medium">Plugin Manager</span>
-                    </button>
-
-                    {pluginPanels.map((panel) => {
-                      const PanelIcon = iconForPluginPanel(panel);
-                      const isOpen = panels[panel.label]?.isOpen;
-
-                      return (
-                        <button
-                          key={panel.label}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setPluginsPopupOpen(false);
-                            onTogglePanel(panel.label);
-                          }}
-                          className={cn(
-                            "flex w-full items-center gap-2 px-3 py-2 rounded-md cursor-pointer transition-colors",
-                            isOpen
-                              ? "bg-space-overlay text-text-primary"
-                              : "text-text-secondary hover:bg-space-overlay hover:text-text-primary",
-                          )}
-                        >
-                          <PanelIcon size={16} />
-                          <span className="text-xs font-medium">{panel.title}</span>
-                        </button>
-                      );
-                    })}
-                  </motion.div>
-                )}
-
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
@@ -160,6 +227,7 @@ export function SpriteActionMenu({
                   <span
                     className={cn(
                       "pointer-events-none absolute bottom-full mb-2 whitespace-nowrap rounded-full border px-2 py-1 text-xs font-medium opacity-0 shadow-panel transition-all duration-150 group-hover:-translate-y-0.5 group-hover:opacity-100 group-focus-visible:-translate-y-0.5 group-focus-visible:opacity-100",
+                      isPluginsButton && pluginsPopupOpen && "hidden",
                       isActive
                         ? "bg-space-overlay border-glow-blue/40 text-text-primary"
                         : "bg-glass border-glass-border text-text-secondary",

--- a/apps/desktop-ui/src/components/sprite/spriteActionMenuPopupPosition.ts
+++ b/apps/desktop-ui/src/components/sprite/spriteActionMenuPopupPosition.ts
@@ -1,0 +1,42 @@
+export interface PluginsPopupPositionInput {
+  /** Width of the popup in px. */
+  popupWidth: number;
+  /** Horizontal offset of the plugins button from the sprite center (from layout). */
+  buttonOffsetX: number;
+  /** Minimum distance (px) the tail must stay from the popup edge. */
+  tailPadding: number;
+}
+
+export interface PluginsPopupPositionResult {
+  /**
+   * Horizontal offset of the tail tip from the popup's left edge (px).
+   * Clamped so the tail stays within the popup body.
+   */
+  tailOffsetX: number;
+}
+
+/**
+ * Compute the tail position for a sprite-centered plugins popup.
+ *
+ * The popup is always horizontally centered above the sprite (via CSS),
+ * so we only need to figure out where the tail arrow should sit so it
+ * points toward the plugins button.
+ */
+export function computePluginsPopupPosition({
+  popupWidth,
+  buttonOffsetX,
+  tailPadding,
+}: PluginsPopupPositionInput): PluginsPopupPositionResult {
+  // The popup is centered, so its own center is at popupWidth / 2.
+  // The button sits buttonOffsetX px from the sprite center, which is
+  // also the popup center.
+  const idealTailX = popupWidth / 2 + buttonOffsetX;
+
+  // Clamp so the tail stays inside the popup body
+  const tailOffsetX = Math.min(
+    Math.max(idealTailX, tailPadding),
+    popupWidth - tailPadding,
+  );
+
+  return { tailOffsetX };
+}

--- a/apps/desktop-ui/src/features/plugins/PluginList.tsx
+++ b/apps/desktop-ui/src/features/plugins/PluginList.tsx
@@ -1,6 +1,5 @@
 import { Puzzle, Wrench, LayoutPanelTop, RefreshCcw, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import type { PluginPanel, PluginSummary } from "@/types/plugin";
 
 interface PluginListProps {
@@ -27,7 +26,7 @@ export function PluginList({
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 min-w-0">
       <div className="flex items-center justify-between rounded-2xl border border-glass-border bg-glass/60 px-4 py-3">
         <div>
           <p className="text-xs uppercase tracking-[0.2em] text-text-muted">Plugin System</p>
@@ -59,21 +58,16 @@ export function PluginList({
             return (
               <section
                 key={plugin.pluginDir}
-                className="rounded-2xl border border-glass-border bg-glass/50 p-4 shadow-panel"
+                className="rounded-2xl border border-glass-border bg-glass/50 p-4 shadow-panel overflow-hidden"
               >
                 <div className="flex items-start justify-between gap-3">
-                  <div className="flex items-start gap-3">
-                    <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-space-overlay text-glow-cyan">
+                  <div className="flex min-w-0 items-start gap-3">
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-space-overlay text-glow-cyan">
                       <Puzzle size={18} />
                     </div>
-                    <div>
-                      <div className="flex items-center gap-2">
-                        <h3 className="text-sm font-semibold text-text-primary">{plugin.name}</h3>
-                        <Badge variant={plugin.enabled ? "default" : "outline"}>
-                          {plugin.enabled ? "Loaded" : "Discovered"}
-                        </Badge>
-                      </div>
-                      <p className="mt-1 text-xs text-text-muted">
+                    <div className="min-w-0">
+                      <h3 className="truncate text-sm font-semibold text-text-primary">{plugin.name}</h3>
+                      <p className="mt-1 truncate text-xs text-text-muted">
                         {plugin.pluginKey} · v{plugin.version}
                         {plugin.author ? ` · ${plugin.author}` : ""}
                       </p>
@@ -82,19 +76,19 @@ export function PluginList({
 
                   {onRemove ? (
                     <Button
-                      size="sm"
+                      size="icon"
                       variant="outline"
                       className="text-danger border-danger/30 hover:bg-danger/10 shrink-0"
+                      title="Remove plugin"
                       onClick={() => void onRemove(plugin.pluginKey)}
                     >
-                      <Trash2 size={14} />
-                      Remove
+                      <Trash2 size={16} />
                     </Button>
                   ) : null}
                 </div>
 
                 {plugin.description ? (
-                  <p className="mt-3 text-sm leading-6 text-text-secondary">{plugin.description}</p>
+                  <p className="mt-3 text-sm leading-6 text-text-secondary break-words">{plugin.description}</p>
                 ) : null}
 
                 <div className="mt-4 grid grid-cols-2 gap-3 text-xs text-text-muted md:grid-cols-3">
@@ -110,12 +104,12 @@ export function PluginList({
                     </div>
                     <div className="mt-1 text-sm font-medium text-text-primary">{plugin.panelCount}</div>
                   </div>
-                  <div className="rounded-xl border border-glass-border bg-space-deep/50 px-3 py-2 col-span-2 md:col-span-1">
-                    <div className="text-text-secondary">Location</div>
-                    <div className="mt-1 truncate text-sm font-medium text-text-primary">
-                      {plugin.pluginDir}
-                    </div>
-                  </div>
+                  <div className="rounded-xl border border-glass-border bg-space-deep/50 px-3 py-2 col-span-2 md:col-span-1 min-w-0">
+                     <div className="text-text-secondary">Location</div>
+                     <div className="mt-1 text-sm font-medium text-text-primary break-all">
+                       {plugin.pluginDir}
+                     </div>
+                   </div>
                 </div>
 
                 {pluginPanels.length > 0 ? (

--- a/apps/desktop-ui/src/features/plugins/PluginManagerPanel.tsx
+++ b/apps/desktop-ui/src/features/plugins/PluginManagerPanel.tsx
@@ -32,7 +32,7 @@ export function PluginManagerPanel() {
   };
 
   return (
-    <div className="h-full flex flex-col">
+    <div className="h-full flex flex-col min-w-0">
       <div className="flex items-center gap-2 px-2 py-2 border-b border-glass-border shrink-0">
         <button
           onClick={() => setActiveTab("installed")}
@@ -59,7 +59,7 @@ export function PluginManagerPanel() {
         </button>
       </div>
 
-      <ScrollArea className="flex-1 pr-2">
+      <ScrollArea className="flex-1 min-w-0">
         {activeTab === "installed" ? (
           <PluginList
             plugins={plugins}

--- a/apps/desktop-ui/src/features/plugins/PluginStoreCatalog.tsx
+++ b/apps/desktop-ui/src/features/plugins/PluginStoreCatalog.tsx
@@ -27,15 +27,15 @@ export function PluginStoreCatalog({
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 min-w-0">
       <div className="flex items-center justify-between rounded-2xl border border-glass-border bg-glass/60 px-4 py-3">
-        <div>
+        <div className="min-w-0">
           <p className="text-xs uppercase tracking-[0.2em] text-text-muted">Plugin Store</p>
           <h2 className="mt-1 text-base font-semibold text-text-primary">
             Available from GitHub
           </h2>
         </div>
-        <Button size="sm" variant="ghost" onClick={onRefresh}>
+        <Button size="sm" variant="ghost" className="shrink-0" onClick={onRefresh}>
           Refresh
         </Button>
       </div>
@@ -58,47 +58,48 @@ export function PluginStoreCatalog({
             return (
               <section
                 key={plugin.pluginKey}
-                className="rounded-2xl border border-glass-border bg-glass/50 p-4 shadow-panel"
+                className="rounded-2xl border border-glass-border bg-glass/50 p-4 shadow-panel overflow-hidden"
               >
                 <div className="flex items-start justify-between gap-3">
-                  <div className="flex items-start gap-3">
-                    <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-space-overlay text-glow-cyan">
+                  <div className="flex min-w-0 items-start gap-3">
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-space-overlay text-glow-cyan">
                       <Puzzle size={18} />
                     </div>
-                    <div>
+                    <div className="min-w-0">
                       <div className="flex items-center gap-2">
-                        <h3 className="text-sm font-semibold text-text-primary">{plugin.name}</h3>
+                        <h3 className="truncate text-sm font-semibold text-text-primary">{plugin.name}</h3>
                         <Badge variant={plugin.installed ? "default" : "outline"}>
                           {plugin.installed ? "Installed" : "Available"}
                         </Badge>
                       </div>
-                      <p className="mt-1 text-xs text-text-muted">
+                      <p className="mt-1 truncate text-xs text-text-muted">
                         {plugin.pluginKey} · v{plugin.version}
                         {plugin.author ? ` · ${plugin.author}` : ""}
                       </p>
                     </div>
                   </div>
 
-                  <div className="flex items-center gap-2">
+                  <div className="flex shrink-0 items-center gap-2">
                     {plugin.installed ? (
                       <Button
-                        size="sm"
+                        size="icon"
                         variant="outline"
                         className="text-danger border-danger/30 hover:bg-danger/10"
+                        title="Remove plugin"
                         onClick={() => void onUninstall(plugin.pluginKey)}
                         disabled={installing}
                       >
                         {installing ? (
                           <Loader2 size={14} className="animate-spin" />
                         ) : (
-                          <Trash2 size={14} />
+                          <Trash2 size={16} />
                         )}
-                        Remove
                       </Button>
                     ) : (
                       <Button
                         size="sm"
                         variant="default"
+                        className="shrink-0"
                         onClick={() => void onInstall(plugin.pluginKey)}
                         disabled={installing}
                       >
@@ -114,7 +115,7 @@ export function PluginStoreCatalog({
                 </div>
 
                 {plugin.description ? (
-                  <p className="mt-3 text-sm leading-6 text-text-secondary">{plugin.description}</p>
+                  <p className="mt-3 text-sm leading-6 text-text-secondary break-words">{plugin.description}</p>
                 ) : null}
 
                 <div className="mt-4 grid grid-cols-2 gap-3 text-xs text-text-muted">

--- a/apps/desktop-ui/src/hooks/use-panel-windows.ts
+++ b/apps/desktop-ui/src/hooks/use-panel-windows.ts
@@ -75,7 +75,7 @@ export async function closePanelWindow(label: PanelLabel): Promise<void> {
 }
 
 export function usePanelWindows() {
-  const { panels: pluginPanels } = usePlugins();
+  const { plugins: installedPlugins, panels: pluginPanels } = usePlugins();
   const [panels, setPanels] = useState<PanelWindowStates>(INITIAL_STATE);
 
   const openPanel = useCallback(async (label: PanelLabel) => {
@@ -123,6 +123,7 @@ export function usePanelWindows() {
   return {
     panels,
     pluginPanels,
+    installedPlugins,
     togglePanel,
   };
 }

--- a/apps/desktop-ui/src/types/window.ts
+++ b/apps/desktop-ui/src/types/window.ts
@@ -50,7 +50,7 @@ export const PANEL_WINDOW_CONFIGS: Record<string, PanelWindowConfig> = {
   "panel-plugins": {
     label: "panel-plugins",
     title: "Peekoo Plugins",
-    width: 420,
-    height: 560,
+    width: 500,
+    height: 600,
   },
 };

--- a/apps/desktop-ui/src/views/SpriteView.tsx
+++ b/apps/desktop-ui/src/views/SpriteView.tsx
@@ -25,7 +25,7 @@ const CLICK_TIME_THRESHOLD_MS = 150;
 export default function SpriteView() {
   const spriteState = useSpriteState();
   const { payload: bubblePayload, visible: bubbleVisible, showBubble, clearBubble } = useSpriteBubble();
-  const { panels, pluginPanels, togglePanel } = usePanelWindows();
+  const { panels, pluginPanels, installedPlugins, togglePanel } = usePanelWindows();
   const [menuOpen, setMenuOpen] = useState(false);
   const [randomTrigger, setRandomTrigger] = useState(0);
   const [moodOverride, setMoodOverride] = useState<string | null>(null);
@@ -174,6 +174,7 @@ export default function SpriteView() {
           onTogglePanel={handleTogglePanel}
           isOpen={menuOpen}
           pluginPanels={pluginPanels}
+          installedPlugins={installedPlugins}
         />
         <SpriteBubble
           payload={bubblePayload}

--- a/apps/desktop-ui/tests/sprite-action-menu-popup-position.test.ts
+++ b/apps/desktop-ui/tests/sprite-action-menu-popup-position.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { computePluginsPopupPosition } from "../src/components/sprite/spriteActionMenuPopupPosition";
+
+describe("computePluginsPopupPosition", () => {
+  test("tail points toward button when button is to the right of center", () => {
+    // Plugins button is 78px right of sprite center, popup is 180px wide
+    const result = computePluginsPopupPosition({
+      popupWidth: 180,
+      buttonOffsetX: 78,
+      tailPadding: 16,
+    });
+
+    // Ideal tail X = 180/2 + 78 = 168, within bounds (16..164) → clamped to 164
+    expect(result.tailOffsetX).toBe(164);
+  });
+
+  test("tail points toward button when button is to the left of center", () => {
+    const result = computePluginsPopupPosition({
+      popupWidth: 180,
+      buttonOffsetX: -78,
+      tailPadding: 16,
+    });
+
+    // Ideal tail X = 180/2 + (-78) = 12, below padding → clamped to 16
+    expect(result.tailOffsetX).toBe(16);
+  });
+
+  test("tail is centered when button is at sprite center", () => {
+    const result = computePluginsPopupPosition({
+      popupWidth: 180,
+      buttonOffsetX: 0,
+      tailPadding: 16,
+    });
+
+    // Ideal tail X = 180/2 + 0 = 90, within bounds
+    expect(result.tailOffsetX).toBe(90);
+  });
+
+  test("tail stays within popup when button offset is very large", () => {
+    const result = computePluginsPopupPosition({
+      popupWidth: 180,
+      buttonOffsetX: 200,
+      tailPadding: 16,
+    });
+
+    // Ideal tail X = 180/2 + 200 = 290, clamped to 180 - 16 = 164
+    expect(result.tailOffsetX).toBe(164);
+  });
+
+  test("tail stays within popup when button offset is very negative", () => {
+    const result = computePluginsPopupPosition({
+      popupWidth: 180,
+      buttonOffsetX: -200,
+      tailPadding: 16,
+    });
+
+    // Ideal tail X = 180/2 + (-200) = -110, clamped to 16
+    expect(result.tailOffsetX).toBe(16);
+  });
+});

--- a/crates/peekoo-agent-app/src/application.rs
+++ b/crates/peekoo-agent-app/src/application.rs
@@ -211,7 +211,7 @@ impl AgentApplication {
     pub fn list_plugin_panels(&self) -> Result<Vec<PluginPanelDto>, String> {
         Ok(self
             .plugin_registry
-            .all_ui_panels()
+            .all_discovered_ui_panels()
             .into_iter()
             .map(|(plugin_key, panel)| PluginPanelDto::from_panel(plugin_key, panel))
             .collect())

--- a/crates/peekoo-agent-app/src/lib.rs
+++ b/crates/peekoo-agent-app/src/lib.rs
@@ -4,6 +4,7 @@ pub mod productivity;
 pub mod settings;
 
 pub use application::AgentApplication;
+pub use peekoo_plugin_store::{PluginSource, StorePluginDto};
 pub use plugin::{PluginNotificationDto, PluginPanelDto, PluginSummaryDto};
 pub use productivity::{PomodoroSessionDto, ProductivityService, TaskDto};
 pub use settings::{
@@ -12,4 +13,3 @@ pub use settings::{
     ProviderCatalogDto, ProviderConfigDto, ProviderRequest, SetApiKeyRequest,
     SetProviderConfigRequest, SettingsService, SkillDto,
 };
-pub use peekoo_plugin_store::{PluginSource, StorePluginDto};

--- a/crates/peekoo-plugin-host/src/registry.rs
+++ b/crates/peekoo-plugin-host/src/registry.rs
@@ -222,18 +222,49 @@ impl PluginRegistry {
         panels
     }
 
-    /// Resolve the HTML entry path for a panel label.
-    pub fn panel_entry_path(&self, label: &str) -> Option<PathBuf> {
-        let plugins = self.plugins.lock().ok()?;
-        for instance in plugins.values() {
-            if let Some(ui_block) = &instance.manifest.ui {
+    /// Return all UI panel definitions across all discovered plugins (on-disk),
+    /// not just runtime-loaded ones.
+    pub fn all_discovered_ui_panels(&self) -> Vec<(String, UiPanelDef)> {
+        let mut panels = Vec::new();
+        for (_, manifest) in self.discover() {
+            if let Some(ui_block) = &manifest.ui {
                 for panel in &ui_block.panels {
-                    if panel.label == label {
-                        return Some(instance.plugin_dir.join(&panel.entry));
+                    panels.push((manifest.plugin.key.clone(), panel.clone()));
+                }
+            }
+        }
+        panels
+    }
+
+    /// Resolve the HTML entry path for a panel label.
+    ///
+    /// Checks loaded plugins first, then falls back to discovered plugins
+    /// so panels remain accessible even when the WASM runtime failed to load.
+    pub fn panel_entry_path(&self, label: &str) -> Option<PathBuf> {
+        // Check loaded plugins first (fast path).
+        if let Ok(plugins) = self.plugins.lock() {
+            for instance in plugins.values() {
+                if let Some(ui_block) = &instance.manifest.ui {
+                    for panel in &ui_block.panels {
+                        if panel.label == label {
+                            return Some(instance.plugin_dir.join(&panel.entry));
+                        }
                     }
                 }
             }
         }
+
+        // Fall back to discovered plugins (on-disk manifests).
+        for (plugin_dir, manifest) in self.discover() {
+            if let Some(ui_block) = &manifest.ui {
+                for panel in &ui_block.panels {
+                    if panel.label == label {
+                        return Some(plugin_dir.join(&panel.entry));
+                    }
+                }
+            }
+        }
+
         None
     }
 

--- a/crates/peekoo-plugin-store/src/lib.rs
+++ b/crates/peekoo-plugin-store/src/lib.rs
@@ -92,7 +92,6 @@ impl PluginStoreService {
             .map_err(|e| format!("Failed to parse GitHub API response: {e}"))?;
 
         let local_plugins = registry.discover();
-        let loaded_keys = registry.loaded_keys();
 
         let mut store_plugins = Vec::new();
 
@@ -104,7 +103,7 @@ impl PluginStoreService {
             match self.fetch_plugin_metadata(&item.name) {
                 Ok(manifest) => {
                     let (installed, source) =
-                        self.check_installation(&manifest.plugin.key, &local_plugins, &loaded_keys);
+                        self.check_installation(&manifest.plugin.key, &local_plugins);
                     let tool_count = manifest
                         .tools
                         .as_ref()
@@ -170,9 +169,7 @@ impl PluginStoreService {
         };
 
         let local_plugins = registry.discover();
-        let loaded_keys = registry.loaded_keys();
-        let (installed, source) =
-            self.check_installation(&plugin_key_loaded, &local_plugins, &loaded_keys);
+        let (installed, source) = self.check_installation(&plugin_key_loaded, &local_plugins);
 
         let tool_count = manifest
             .tools
@@ -229,7 +226,6 @@ impl PluginStoreService {
         &self,
         plugin_key: &str,
         local_plugins: &[(PathBuf, PluginManifest)],
-        loaded_keys: &[String],
     ) -> (bool, PluginSource) {
         let global_plugins_dir = peekoo_global_data_dir()
             .map(|d| d.join("plugins"))
@@ -242,8 +238,7 @@ impl PluginStoreService {
                 } else {
                     PluginSource::Workspace
                 };
-                let installed = loaded_keys.iter().any(|k| k == plugin_key);
-                return (installed, source);
+                return (true, source);
             }
         }
 
@@ -424,9 +419,7 @@ mod tests {
     fn check_installation_returns_not_installed_when_not_in_registry() {
         let store = make_store();
         let local_plugins: Vec<(PathBuf, PluginManifest)> = vec![];
-        let loaded_keys: Vec<String> = vec![];
-        let (installed, source) =
-            store.check_installation("unknown-plugin", &local_plugins, &loaded_keys);
+        let (installed, source) = store.check_installation("unknown-plugin", &local_plugins);
         assert!(!installed);
         assert_eq!(source, PluginSource::None);
     }
@@ -448,10 +441,8 @@ wasm = "plugin.wasm"
         // Simulate a workspace path (not under global plugins dir)
         let workspace_dir = PathBuf::from("/home/user/myproject/plugins/my-plugin");
         let local_plugins = vec![(workspace_dir, manifest)];
-        let loaded_keys = vec!["my-plugin".to_string()];
 
-        let (installed, source) =
-            store.check_installation("my-plugin", &local_plugins, &loaded_keys);
+        let (installed, source) = store.check_installation("my-plugin", &local_plugins);
         assert!(installed);
         assert_eq!(source, PluginSource::Workspace);
     }
@@ -476,11 +467,39 @@ wasm = "plugin.wasm"
             .join("plugins")
             .join("store-plugin");
         let local_plugins = vec![(global_dir, manifest)];
-        let loaded_keys = vec!["store-plugin".to_string()];
 
-        let (installed, source) =
-            store.check_installation("store-plugin", &local_plugins, &loaded_keys);
+        let (installed, source) = store.check_installation("store-plugin", &local_plugins);
         assert!(installed);
+        assert_eq!(source, PluginSource::Store);
+    }
+
+    #[test]
+    fn check_installation_treats_discovered_but_not_loaded_plugin_as_installed() {
+        // A plugin that exists on disk (returned by discover()) but failed to
+        // load into the runtime should still be considered "installed".
+        let store = make_store();
+        let manifest = parse_manifest(
+            r#"
+[plugin]
+key = "broken-plugin"
+name = "Broken Plugin"
+version = "1.0.0"
+wasm = "plugin.wasm"
+"#,
+        )
+        .unwrap();
+
+        let global_dir = peekoo_global_data_dir()
+            .unwrap()
+            .join("plugins")
+            .join("broken-plugin");
+        let local_plugins = vec![(global_dir, manifest)];
+
+        let (installed, source) = store.check_installation("broken-plugin", &local_plugins);
+        assert!(
+            installed,
+            "discovered plugin should be installed=true even if not loaded"
+        );
         assert_eq!(source, PluginSource::Store);
     }
 


### PR DESCRIPTION
## What
- Fix \`check_installation()\` to return \`installed: true\` based on presence in \`discover()\` (on-disk), not \`loaded_keys()\` (runtime active)
- Remove unused \`loaded_keys\` parameter from \`check_installation\` and its call sites
- Fix sprite sub-menu to show all installed plugins (not just loaded+UI-panel plugins)
- Fix \`PluginList\` overflow — Remove button was being clipped; fix with \`min-w-0\` + \`shrink-0\`
- Rename sprite sub-menu label \"Plugin Manager\" → \"Plugins\"
- Expose \`installedPlugins\` from \`use-panel-windows.ts\` and pass to \`SpriteActionMenu\`
- Include AI memory changelogs and architecture diagrams

## Why
**Installed flag bug**: A plugin in \`~/.peekoo/plugins/<key>/\` that failed to load (e.g. WASM at wrong path) should still be considered \"installed\" so the Store tab shows the Remove button and users can uninstall broken plugins.

**Sprite sub-menu bug**: The sub-menu only showed plugins with loaded UI panels. Tool-only plugins and discovered-but-not-loaded plugins were silently omitted.

## Problem (installed flag)
Before this fix:
- \`health-reminders\` installed manually with flat layout (WASM in root, not \`target/.../release/\`)
- Plugin failed to load at startup → showed as \"Discovered\" not \"Loaded\"
- \`check_installation\` used \`loaded_keys\` → returned \`installed: false\`
- Store tab showed \"Available\" instead of \"Installed\" — no Remove button

## Solution
\`installed\` now reflects on-disk presence only. Whether the plugin loaded successfully is a separate concern.

## Test
New test: \`check_installation_treats_discovered_but_not_loaded_plugin_as_installed\`

## Checklist
- [x] TDD: wrote failing test first
- [x] All tests pass (81 tests)
- [x] \`just check\`, \`just lint\` clean
- [x] TypeScript type check clean
- [x] Rebased onto merged \`master\` (PR #44)