### PR TITLE
feat(plugins): add persisted plugin store management

### DIFF
--- a/ai/memories/changelogs/202603101220-feat-plugin-store-management.md
+++ b/ai/memories/changelogs/202603101220-feat-plugin-store-management.md
@@ -1,0 +1,22 @@
+## 2026-03-10 12:20: feat: Add plugin store management improvements
+
+**What changed:**
+- Added persisted plugin enable and disable behavior backed by the existing `plugins.enabled` database column.
+- Updated startup loading so disabled plugins stay installed but are not loaded into the runtime or exposed as active plugin panels.
+- Added Tauri commands and desktop UI controls for enabling and disabling installed plugins.
+- Updated the plugin store UI to show update availability and let users trigger updates.
+- Hid disabled plugins, and enabled plugins without UI panels, from the sprite plugin submenu.
+
+**Why:**
+- Users need a basic plugin catalog plus clear control over whether installed plugins are active in the app.
+- Disabled plugins should not appear as runnable UI actions from the sprite menu.
+
+**Files affected:**
+- `crates/peekoo-plugin-host/src/registry.rs`
+- `crates/peekoo-agent-app/src/application.rs`
+- `apps/desktop-tauri/src-tauri/src/lib.rs`
+- `apps/desktop-ui/src/hooks/use-plugins.ts`
+- `apps/desktop-ui/src/features/plugins/PluginManagerPanel.tsx`
+- `apps/desktop-ui/src/features/plugins/PluginList.tsx`
+- `apps/desktop-ui/src/features/plugins/PluginStoreCatalog.tsx`
+- `apps/desktop-ui/src/components/sprite/SpriteActionMenu.tsx`

--- a/apps/desktop-tauri/src-tauri/src/lib.rs
+++ b/apps/desktop-tauri/src-tauri/src/lib.rs
@@ -287,6 +287,28 @@ async fn plugin_dispatch_event(
 }
 
 #[tauri::command]
+async fn plugin_enable(
+    plugin_key: String,
+    window: Window,
+    state: State<'_, AgentState>,
+) -> Result<(), String> {
+    state.app.enable_plugin(&plugin_key)?;
+    let _ = window.emit("plugins-changed", ());
+    Ok(())
+}
+
+#[tauri::command]
+async fn plugin_disable(
+    plugin_key: String,
+    window: Window,
+    state: State<'_, AgentState>,
+) -> Result<(), String> {
+    state.app.disable_plugin(&plugin_key)?;
+    let _ = window.emit("plugins-changed", ());
+    Ok(())
+}
+
+#[tauri::command]
 async fn plugin_store_catalog(state: State<'_, AgentState>) -> Result<Vec<StorePluginDto>, String> {
     state.app.store_catalog()
 }
@@ -404,6 +426,8 @@ pub fn run() {
             plugin_query_data,
             plugin_panel_html,
             plugin_dispatch_event,
+            plugin_enable,
+            plugin_disable,
             plugin_store_catalog,
             plugin_store_install,
             plugin_store_update,

--- a/apps/desktop-ui/src/components/sprite/SpriteActionMenu.tsx
+++ b/apps/desktop-ui/src/components/sprite/SpriteActionMenu.tsx
@@ -50,6 +50,13 @@ export function SpriteActionMenu({
   installedPlugins = [],
 }: SpriteActionMenuProps) {
   const [pluginsPopupOpen, setPluginsPopupOpen] = useState(false);
+  const enabledPlugins = installedPlugins.filter((plugin) => {
+    if (!plugin.enabled) {
+      return false;
+    }
+
+    return pluginPanels.some((panel) => panel.pluginKey === plugin.pluginKey);
+  });
 
   const items: MenuItemConfig[] = getSpriteActionMenuItems().map((item) => {
     return {
@@ -146,7 +153,7 @@ export function SpriteActionMenu({
                     <span className="text-xs font-medium whitespace-nowrap">Plugins</span>
                   </button>
 
-                  {installedPlugins.map((plugin) => {
+                  {enabledPlugins.map((plugin) => {
                     const uiPanel = pluginPanels.find(
                       (p) => p.pluginKey === plugin.pluginKey,
                     );

--- a/apps/desktop-ui/src/features/plugins/PluginList.tsx
+++ b/apps/desktop-ui/src/features/plugins/PluginList.tsx
@@ -1,4 +1,5 @@
-import { Puzzle, Wrench, LayoutPanelTop, RefreshCcw, Trash2 } from "lucide-react";
+import { Loader2, LayoutPanelTop, Puzzle, RefreshCcw, Trash2, Wrench } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { PluginPanel, PluginSummary } from "@/types/plugin";
 
@@ -9,6 +10,8 @@ interface PluginListProps {
   error: string | null;
   onRefresh: () => void;
   onOpenPanel: (label: string) => void;
+  onToggleEnabled: (pluginKey: string, enabled: boolean) => Promise<void>;
+  isToggling: (pluginKey: string) => boolean;
   onRemove?: (pluginKey: string) => Promise<void>;
 }
 
@@ -19,6 +22,8 @@ export function PluginList({
   error,
   onRefresh,
   onOpenPanel,
+  onToggleEnabled,
+  isToggling,
   onRemove,
 }: PluginListProps) {
   if (isLoading && plugins.length === 0) {
@@ -54,6 +59,7 @@ export function PluginList({
         <div className="space-y-3">
           {plugins.map((plugin) => {
             const pluginPanels = panels.filter((panel) => panel.pluginKey === plugin.pluginKey);
+            const toggling = isToggling(plugin.pluginKey);
 
             return (
               <section
@@ -66,7 +72,12 @@ export function PluginList({
                       <Puzzle size={18} />
                     </div>
                     <div className="min-w-0">
-                      <h3 className="truncate text-sm font-semibold text-text-primary">{plugin.name}</h3>
+                      <div className="flex items-center gap-2">
+                        <h3 className="truncate text-sm font-semibold text-text-primary">{plugin.name}</h3>
+                        <Badge variant={plugin.enabled ? "default" : "outline"}>
+                          {plugin.enabled ? "Enabled" : "Disabled"}
+                        </Badge>
+                      </div>
                       <p className="mt-1 truncate text-xs text-text-muted">
                         {plugin.pluginKey} · v{plugin.version}
                         {plugin.author ? ` · ${plugin.author}` : ""}
@@ -74,17 +85,30 @@ export function PluginList({
                     </div>
                   </div>
 
-                  {onRemove ? (
+                  <div className="flex shrink-0 items-center gap-2">
                     <Button
-                      size="icon"
-                      variant="outline"
-                      className="text-danger border-danger/30 hover:bg-danger/10 shrink-0"
-                      title="Remove plugin"
-                      onClick={() => void onRemove(plugin.pluginKey)}
+                      size="sm"
+                      variant={plugin.enabled ? "outline" : "default"}
+                      className={plugin.enabled ? "bg-space-deep/50" : undefined}
+                      onClick={() => void onToggleEnabled(plugin.pluginKey, !plugin.enabled)}
+                      disabled={toggling}
                     >
-                      <Trash2 size={16} />
+                      {toggling ? <Loader2 size={14} className="animate-spin" /> : null}
+                      {plugin.enabled ? "Disable" : "Enable"}
                     </Button>
-                  ) : null}
+                    {onRemove ? (
+                      <Button
+                        size="icon"
+                        variant="outline"
+                        className="text-danger border-danger/30 hover:bg-danger/10 shrink-0"
+                        title="Remove plugin"
+                        onClick={() => void onRemove(plugin.pluginKey)}
+                        disabled={toggling}
+                      >
+                        <Trash2 size={16} />
+                      </Button>
+                    ) : null}
+                  </div>
                 </div>
 
                 {plugin.description ? (
@@ -131,6 +155,12 @@ export function PluginList({
                       ))}
                     </div>
                   </div>
+                ) : null}
+
+                {!plugin.enabled ? (
+                  <p className="mt-4 text-xs text-text-muted">
+                    Enable this plugin to open its panels and use its runtime capabilities.
+                  </p>
                 ) : null}
               </section>
             );

--- a/apps/desktop-ui/src/features/plugins/PluginManagerPanel.tsx
+++ b/apps/desktop-ui/src/features/plugins/PluginManagerPanel.tsx
@@ -9,13 +9,14 @@ import { PluginStoreCatalog } from "./PluginStoreCatalog";
 type TabKey = "installed" | "store";
 
 export function PluginManagerPanel() {
-  const { plugins, panels, isLoading, error, refresh } = usePlugins();
+  const { plugins, panels, isLoading, error, refresh, setPluginEnabled, isToggling } = usePlugins();
   const {
     catalog,
     isLoading: isStoreLoading,
     error: storeError,
     fetchCatalog,
     install,
+    update,
     uninstall,
     isInstalling,
   } = usePluginStore();
@@ -29,6 +30,17 @@ export function PluginManagerPanel() {
   const handleUninstall = async (pluginKey: string) => {
     await uninstall(pluginKey);
     await refresh();
+  };
+
+  const handleToggle = async (pluginKey: string, enabled: boolean) => {
+    await setPluginEnabled(pluginKey, enabled);
+    await refresh();
+  };
+
+  const handleUpdate = async (pluginKey: string) => {
+    await update(pluginKey);
+    await refresh();
+    await fetchCatalog();
   };
 
   return (
@@ -70,6 +82,8 @@ export function PluginManagerPanel() {
             onOpenPanel={(label) => {
               void openPanelWindow(label, panels);
             }}
+            onToggleEnabled={handleToggle}
+            isToggling={isToggling}
             onRemove={handleUninstall}
           />
         ) : (
@@ -78,6 +92,7 @@ export function PluginManagerPanel() {
             isLoading={isStoreLoading}
             error={storeError}
             onInstall={handleInstall}
+            onUpdate={handleUpdate}
             onUninstall={handleUninstall}
             isInstalling={isInstalling}
             onRefresh={fetchCatalog}

--- a/apps/desktop-ui/src/features/plugins/PluginStoreCatalog.tsx
+++ b/apps/desktop-ui/src/features/plugins/PluginStoreCatalog.tsx
@@ -1,4 +1,4 @@
-import { Puzzle, Wrench, LayoutPanelTop, Download, Trash2, Loader2 } from "lucide-react";
+import { Download, LayoutPanelTop, Loader2, Puzzle, RefreshCcw, Trash2, Wrench } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import type { StorePlugin } from "@/types/plugin";
@@ -8,6 +8,7 @@ interface PluginStoreCatalogProps {
   isLoading: boolean;
   error: string | null;
   onInstall: (pluginKey: string) => Promise<void>;
+  onUpdate: (pluginKey: string) => Promise<void>;
   onUninstall: (pluginKey: string) => Promise<void>;
   isInstalling: (pluginKey: string) => boolean;
   onRefresh: () => void;
@@ -18,6 +19,7 @@ export function PluginStoreCatalog({
   isLoading,
   error,
   onInstall,
+  onUpdate,
   onUninstall,
   isInstalling,
   onRefresh,
@@ -36,6 +38,7 @@ export function PluginStoreCatalog({
           </h2>
         </div>
         <Button size="sm" variant="ghost" className="shrink-0" onClick={onRefresh}>
+          <RefreshCcw size={14} />
           Refresh
         </Button>
       </div>
@@ -71,6 +74,7 @@ export function PluginStoreCatalog({
                         <Badge variant={plugin.installed ? "default" : "outline"}>
                           {plugin.installed ? "Installed" : "Available"}
                         </Badge>
+                        {plugin.hasUpdate ? <Badge variant="secondary">Update available</Badge> : null}
                       </div>
                       <p className="mt-1 truncate text-xs text-text-muted">
                         {plugin.pluginKey} · v{plugin.version}
@@ -81,20 +85,38 @@ export function PluginStoreCatalog({
 
                   <div className="flex shrink-0 items-center gap-2">
                     {plugin.installed ? (
-                      <Button
-                        size="icon"
-                        variant="outline"
-                        className="text-danger border-danger/30 hover:bg-danger/10"
-                        title="Remove plugin"
-                        onClick={() => void onUninstall(plugin.pluginKey)}
-                        disabled={installing}
-                      >
-                        {installing ? (
-                          <Loader2 size={14} className="animate-spin" />
-                        ) : (
-                          <Trash2 size={16} />
-                        )}
-                      </Button>
+                      <>
+                        {plugin.hasUpdate ? (
+                          <Button
+                            size="sm"
+                            variant="secondary"
+                            className="shrink-0"
+                            onClick={() => void onUpdate(plugin.pluginKey)}
+                            disabled={installing}
+                          >
+                            {installing ? (
+                              <Loader2 size={14} className="animate-spin" />
+                            ) : (
+                              <RefreshCcw size={14} />
+                            )}
+                            Update
+                          </Button>
+                        ) : null}
+                        <Button
+                          size="icon"
+                          variant="outline"
+                          className="text-danger border-danger/30 hover:bg-danger/10"
+                          title="Remove plugin"
+                          onClick={() => void onUninstall(plugin.pluginKey)}
+                          disabled={installing}
+                        >
+                          {installing ? (
+                            <Loader2 size={14} className="animate-spin" />
+                          ) : (
+                            <Trash2 size={16} />
+                          )}
+                        </Button>
+                      </>
                     ) : (
                       <Button
                         size="sm"

--- a/apps/desktop-ui/src/hooks/use-plugins.ts
+++ b/apps/desktop-ui/src/hooks/use-plugins.ts
@@ -13,6 +13,7 @@ export function usePlugins() {
   const [panels, setPanels] = useState<PluginPanel[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [toggling, setToggling] = useState<Set<string>>(new Set());
 
   const refresh = useCallback(async () => {
     setIsLoading(true);
@@ -43,11 +44,43 @@ export function usePlugins() {
     };
   }, [refresh]);
 
+  const setPluginEnabled = useCallback(async (pluginKey: string, enabled: boolean) => {
+    setToggling((prev) => new Set(prev).add(pluginKey));
+    setError(null);
+    try {
+      await invoke(enabled ? "plugin_enable" : "plugin_disable", { pluginKey });
+      setPlugins((prev) =>
+        prev.map((plugin) =>
+          plugin.pluginKey === pluginKey ? { ...plugin, enabled } : plugin,
+        ),
+      );
+      if (!enabled) {
+        setPanels((prev) => prev.filter((panel) => panel.pluginKey !== pluginKey));
+      }
+    } catch (err) {
+      setError(String(err));
+      throw err;
+    } finally {
+      setToggling((prev) => {
+        const next = new Set(prev);
+        next.delete(pluginKey);
+        return next;
+      });
+    }
+  }, []);
+
+  const isToggling = useCallback(
+    (pluginKey: string) => toggling.has(pluginKey),
+    [toggling],
+  );
+
   return {
     plugins,
     panels,
     isLoading,
     error,
     refresh,
+    setPluginEnabled,
+    isToggling,
   };
 }

--- a/crates/peekoo-agent-app/src/application.rs
+++ b/crates/peekoo-agent-app/src/application.rs
@@ -195,26 +195,60 @@ impl AgentApplication {
     }
 
     pub fn list_plugins(&self) -> Result<Vec<PluginSummaryDto>, String> {
-        let loaded = self.plugin_registry.loaded_keys();
         let plugins = self
             .plugin_registry
             .discover()
             .into_iter()
-            .map(|(plugin_dir, manifest)| {
-                let enabled = loaded.iter().any(|key| key == &manifest.plugin.key);
-                manifest_to_summary(&manifest, plugin_dir, enabled)
-            })
-            .collect();
+            .map(
+                |(plugin_dir, manifest)| -> Result<PluginSummaryDto, String> {
+                    self.plugin_registry
+                        .sync_plugin_registration(&plugin_dir)
+                        .map_err(|e| e.to_string())?;
+                    let enabled = self
+                        .plugin_registry
+                        .is_plugin_enabled(&manifest.plugin.key)
+                        .map_err(|e| e.to_string())?;
+                    Ok(manifest_to_summary(&manifest, plugin_dir, enabled))
+                },
+            )
+            .collect::<Result<Vec<_>, String>>()?;
         Ok(plugins)
     }
 
     pub fn list_plugin_panels(&self) -> Result<Vec<PluginPanelDto>, String> {
         Ok(self
             .plugin_registry
-            .all_discovered_ui_panels()
+            .all_ui_panels()
             .into_iter()
             .map(|(plugin_key, panel)| PluginPanelDto::from_panel(plugin_key, panel))
             .collect())
+    }
+
+    pub fn enable_plugin(&self, plugin_key: &str) -> Result<(), String> {
+        let plugin_dir = self
+            .plugin_registry
+            .discover()
+            .into_iter()
+            .find_map(|(plugin_dir, manifest)| {
+                (manifest.plugin.key == plugin_key).then_some(plugin_dir)
+            })
+            .ok_or_else(|| format!("Plugin not found: {plugin_key}"))?;
+
+        self.plugin_registry
+            .install_plugin(&plugin_dir)
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    pub fn disable_plugin(&self, plugin_key: &str) -> Result<(), String> {
+        self.plugin_registry
+            .set_plugin_enabled(plugin_key, false)
+            .map_err(|e| e.to_string())?;
+
+        match self.plugin_registry.unload_plugin(plugin_key) {
+            Ok(()) | Err(peekoo_plugin_host::PluginError::NotFound(_)) => Ok(()),
+            Err(err) => Err(err.to_string()),
+        }
     }
 
     pub fn call_plugin_tool(&self, tool_name: &str, args_json: &str) -> Result<String, String> {
@@ -393,6 +427,37 @@ fn create_plugin_registry() -> Result<Arc<PluginRegistry>, String> {
 
 fn install_discovered_plugins(plugin_registry: &Arc<PluginRegistry>) {
     for (plugin_dir, manifest) in plugin_registry.discover() {
+        let enabled = match plugin_registry.sync_plugin_registration(&plugin_dir) {
+            Ok(_) => match plugin_registry.is_plugin_enabled(&manifest.plugin.key) {
+                Ok(enabled) => enabled,
+                Err(err) => {
+                    tracing::warn!(
+                        plugin = manifest.plugin.key.as_str(),
+                        dir = %plugin_dir.display(),
+                        "Skipping plugin during startup: {err}"
+                    );
+                    continue;
+                }
+            },
+            Err(err) => {
+                tracing::warn!(
+                    plugin = manifest.plugin.key.as_str(),
+                    dir = %plugin_dir.display(),
+                    "Skipping plugin during startup: {err}"
+                );
+                continue;
+            }
+        };
+
+        if !enabled {
+            tracing::info!(
+                plugin = manifest.plugin.key.as_str(),
+                dir = %plugin_dir.display(),
+                "Plugin discovered but left disabled during startup"
+            );
+            continue;
+        }
+
         match plugin_registry.install_plugin(&plugin_dir) {
             Ok(key) => tracing::info!(plugin = key.as_str(), "Plugin installed and loaded"),
             Err(err) => tracing::warn!(
@@ -401,5 +466,76 @@ fn install_discovered_plugins(plugin_registry: &Arc<PluginRegistry>) {
                 "Skipping plugin during startup: {err}"
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use peekoo_plugin_host::PluginRegistry;
+    use rusqlite::Connection;
+
+    use super::install_discovered_plugins;
+
+    fn test_registry(plugin_name: &str) -> Arc<PluginRegistry> {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        conn.execute_batch(
+            r#"
+            CREATE TABLE plugins (
+              id TEXT PRIMARY KEY,
+              plugin_key TEXT NOT NULL,
+              version TEXT NOT NULL,
+              plugin_type TEXT NOT NULL,
+              enabled INTEGER NOT NULL DEFAULT 1,
+              manifest_json TEXT NOT NULL,
+              installed_at TEXT NOT NULL
+            );
+
+            CREATE TABLE plugin_permissions (
+              id TEXT PRIMARY KEY,
+              plugin_id TEXT NOT NULL,
+              capability TEXT NOT NULL,
+              granted INTEGER NOT NULL
+            );
+
+            CREATE TABLE plugin_state (
+              id TEXT PRIMARY KEY,
+              plugin_id TEXT NOT NULL,
+              state_key TEXT NOT NULL,
+              value_json TEXT NOT NULL,
+              updated_at TEXT NOT NULL
+            );
+            "#,
+        )
+        .expect("plugin schema");
+
+        let plugin_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../plugins")
+            .join(plugin_name);
+
+        Arc::new(PluginRegistry::new(
+            vec![plugin_dir],
+            Arc::new(Mutex::new(conn)),
+        ))
+    }
+
+    #[test]
+    fn startup_skips_loading_plugins_marked_disabled() {
+        let registry = test_registry("health-reminders");
+        let plugin_dir =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../plugins/health-reminders");
+
+        registry
+            .sync_plugin_registration(&plugin_dir)
+            .expect("plugin should register");
+        registry
+            .set_plugin_enabled("health-reminders", false)
+            .expect("plugin should disable");
+
+        install_discovered_plugins(&registry);
+
+        assert!(registry.loaded_keys().is_empty());
+        assert!(registry.all_ui_panels().is_empty());
     }
 }

--- a/crates/peekoo-plugin-host/src/registry.rs
+++ b/crates/peekoo-plugin-host/src/registry.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 
 use crate::error::PluginError;
 use crate::events::EventBus;
@@ -78,6 +78,14 @@ impl PluginRegistry {
         let manifest = manifest::load_manifest(&manifest_path)?;
         let key = manifest.plugin.key.clone();
 
+        if self
+            .loaded_keys()
+            .iter()
+            .any(|loaded_key| loaded_key == &key)
+        {
+            return Ok(key);
+        }
+
         // Ensure the plugin row exists in the DB so permission / state queries work.
         self.ensure_plugin_row(&key, &manifest)?;
 
@@ -116,8 +124,61 @@ impl PluginRegistry {
 
         self.ensure_plugin_row(&key, &manifest)?;
         self.permissions.grant_all_required(&key, &manifest)?;
+        self.set_plugin_enabled(&key, true)?;
 
         self.load_plugin(plugin_dir)
+    }
+
+    /// Ensure a discovered plugin has a backing row in the database.
+    pub fn sync_plugin_registration(
+        &self,
+        plugin_dir: &Path,
+    ) -> Result<PluginManifest, PluginError> {
+        let manifest_path = plugin_dir.join("peekoo-plugin.toml");
+        let manifest = manifest::load_manifest(&manifest_path)?;
+        self.ensure_plugin_row(&manifest.plugin.key, &manifest)?;
+        Ok(manifest)
+    }
+
+    /// Read the persisted enabled state for a plugin.
+    pub fn is_plugin_enabled(&self, plugin_key: &str) -> Result<bool, PluginError> {
+        let conn = self
+            .db_conn
+            .lock()
+            .map_err(|e| PluginError::Internal(e.to_string()))?;
+
+        let enabled = conn
+            .query_row(
+                "SELECT enabled FROM plugins WHERE plugin_key = ?1",
+                rusqlite::params![plugin_key],
+                |row| row.get::<_, bool>(0),
+            )
+            .optional()
+            .map_err(|e| PluginError::Internal(e.to_string()))?
+            .ok_or_else(|| PluginError::NotFound(plugin_key.to_string()))?;
+
+        Ok(enabled)
+    }
+
+    /// Persist the enabled state for a plugin.
+    pub fn set_plugin_enabled(&self, plugin_key: &str, enabled: bool) -> Result<(), PluginError> {
+        let conn = self
+            .db_conn
+            .lock()
+            .map_err(|e| PluginError::Internal(e.to_string()))?;
+
+        let updated = conn
+            .execute(
+                "UPDATE plugins SET enabled = ?2 WHERE plugin_key = ?1",
+                rusqlite::params![plugin_key, enabled],
+            )
+            .map_err(|e| PluginError::Internal(e.to_string()))?;
+
+        if updated == 0 {
+            return Err(PluginError::NotFound(plugin_key.to_string()));
+        }
+
+        Ok(())
     }
 
     /// Unload a plugin by key.
@@ -351,4 +412,90 @@ pub fn start_tick_timer(registry: Arc<PluginRegistry>) {
             registry.dispatch_event("timer:tick", &payload.to_string());
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use rusqlite::Connection;
+
+    use super::PluginRegistry;
+
+    fn test_registry(plugin_dirs: Vec<std::path::PathBuf>) -> PluginRegistry {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        conn.execute_batch(
+            r#"
+            CREATE TABLE plugins (
+              id TEXT PRIMARY KEY,
+              plugin_key TEXT NOT NULL,
+              version TEXT NOT NULL,
+              plugin_type TEXT NOT NULL,
+              enabled INTEGER NOT NULL DEFAULT 1,
+              manifest_json TEXT NOT NULL,
+              installed_at TEXT NOT NULL
+            );
+
+            CREATE TABLE plugin_permissions (
+              id TEXT PRIMARY KEY,
+              plugin_id TEXT NOT NULL,
+              capability TEXT NOT NULL,
+              granted INTEGER NOT NULL
+            );
+
+            CREATE TABLE plugin_state (
+              id TEXT PRIMARY KEY,
+              plugin_id TEXT NOT NULL,
+              state_key TEXT NOT NULL,
+              value_json TEXT NOT NULL,
+              updated_at TEXT NOT NULL
+            );
+            "#,
+        )
+        .expect("plugin schema");
+
+        PluginRegistry::new(plugin_dirs, Arc::new(Mutex::new(conn)))
+    }
+
+    fn sample_plugin_dir(name: &str) -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../plugins")
+            .join(name)
+    }
+
+    #[test]
+    fn discovered_plugin_defaults_to_enabled_when_registered() {
+        let plugin_dir = sample_plugin_dir("health-reminders");
+        let registry = test_registry(vec![plugin_dir.clone()]);
+
+        let manifest = registry
+            .sync_plugin_registration(&plugin_dir)
+            .expect("plugin should register");
+
+        assert_eq!(manifest.plugin.key, "health-reminders");
+        assert!(
+            registry
+                .is_plugin_enabled("health-reminders")
+                .expect("enabled state should exist")
+        );
+    }
+
+    #[test]
+    fn disabling_plugin_persists_enabled_state() {
+        let plugin_dir = sample_plugin_dir("health-reminders");
+        let registry = test_registry(vec![plugin_dir.clone()]);
+
+        registry
+            .sync_plugin_registration(&plugin_dir)
+            .expect("plugin should register");
+        registry
+            .set_plugin_enabled("health-reminders", false)
+            .expect("plugin should disable");
+
+        assert!(
+            !registry
+                .is_plugin_enabled("health-reminders")
+                .expect("enabled state should exist")
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add persisted enable/disable controls for installed plugins and only load enabled plugins at startup
- update the desktop plugin management UI to browse the catalog, toggle installed plugins, and surface future update actions
- hide disabled or non-panel plugins from the sprite plugin submenu and record the change in AI memory

## Testing
- cargo test -p peekoo-plugin-host -p peekoo-agent-app
- just check
- bun run build

Closes #32