### PR TITLE
chore: Add .workspaces to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ plugins/*/Cargo.lock
 
 # Development log files
 /logs/
+
+# JJ workspaces
+.workspaces/


### PR DESCRIPTION
## Summary
- Add `.workspaces` directory to `.gitignore` to exclude jj workspaces from version control
- Update `skills-lock.json` to remove unused entries