### PR TITLE
fix(deps): disable wasm-host in pi_agent_rust to resolve Windows LNK1169

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,15 +686,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "bitstream-io"
 version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,16 +1454,7 @@ version = "0.124.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b27381757f9295b67e558f4c64a83bfe7c6e82daad1ba4f8a948482c5de56ee9"
 dependencies = [
- "cranelift-assembler-x64-meta 0.124.3",
-]
-
-[[package]]
-name = "cranelift-assembler-x64"
-version = "0.128.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50a04121a197fde2fe896f8e7cac9812fc41ed6ee9c63e1906090f9f497845f6"
-dependencies = [
- "cranelift-assembler-x64-meta 0.128.4",
+ "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
@@ -1481,16 +1463,7 @@ version = "0.124.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e2ef32a4dbf1b380632a889995156080ecc0f1e07ac8eaa3f6325e4bd14ad8a"
 dependencies = [
- "cranelift-srcgen 0.124.3",
-]
-
-[[package]]
-name = "cranelift-assembler-x64-meta"
-version = "0.128.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a09e699a94f477303820fb2167024f091543d6240783a2d3b01a3f21c42bc744"
-dependencies = [
- "cranelift-srcgen 0.128.4",
+ "cranelift-srcgen",
 ]
 
 [[package]]
@@ -1499,16 +1472,7 @@ version = "0.124.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b71c01a8007dd54330c8d73edeb82a8fc1a7143884af2f319e97340e290939b"
 dependencies = [
- "cranelift-entity 0.124.3",
-]
-
-[[package]]
-name = "cranelift-bforest"
-version = "0.128.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07732c662a9755529e332d86f8c5842171f6e98ba4d5976a178043dad838654"
-dependencies = [
- "cranelift-entity 0.128.4",
+ "cranelift-entity",
 ]
 
 [[package]]
@@ -1522,67 +1486,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-bitset"
-version = "0.128.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18391da761cf362a06def7a7cf11474d79e55801dd34c2e9ba105b33dc0aef88"
-dependencies = [
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "cranelift-codegen"
 version = "0.124.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2060d8c75772e5208a9d3b766d9eb975bfc18ac459b75a0a2b2a72769a2f6da6"
 dependencies = [
  "bumpalo",
- "cranelift-assembler-x64 0.124.3",
- "cranelift-bforest 0.124.3",
- "cranelift-bitset 0.124.3",
- "cranelift-codegen-meta 0.124.3",
- "cranelift-codegen-shared 0.124.3",
- "cranelift-control 0.124.3",
- "cranelift-entity 0.124.3",
- "cranelift-isle 0.124.3",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
  "gimli",
  "hashbrown 0.15.5",
  "log",
- "pulley-interpreter 37.0.3",
+ "pulley-interpreter",
  "regalloc2",
  "rustc-hash",
  "serde",
  "smallvec",
  "target-lexicon 0.13.5",
- "wasmtime-internal-math 37.0.3",
-]
-
-[[package]]
-name = "cranelift-codegen"
-version = "0.128.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3a09b3042c69810d255aef59ddc3b3e4c0644d1d90ecfd6e3837798cc88a3c"
-dependencies = [
- "bumpalo",
- "cranelift-assembler-x64 0.128.4",
- "cranelift-bforest 0.128.4",
- "cranelift-bitset 0.128.4",
- "cranelift-codegen-meta 0.128.4",
- "cranelift-codegen-shared 0.128.4",
- "cranelift-control 0.128.4",
- "cranelift-entity 0.128.4",
- "cranelift-isle 0.128.4",
- "gimli",
- "hashbrown 0.15.5",
- "log",
- "pulley-interpreter 41.0.4",
- "regalloc2",
- "rustc-hash",
- "serde",
- "smallvec",
- "target-lexicon 0.13.5",
- "wasmtime-internal-math 41.0.4",
+ "wasmtime-internal-math",
 ]
 
 [[package]]
@@ -1591,24 +1518,11 @@ version = "0.124.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "887e3ab41a8a75cb6b68c5fc686158b6083f1ad49cf52f2da7538fba17ff0be6"
 dependencies = [
- "cranelift-assembler-x64-meta 0.124.3",
- "cranelift-codegen-shared 0.124.3",
- "cranelift-srcgen 0.124.3",
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
  "heck 0.5.0",
- "pulley-interpreter 37.0.3",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
-version = "0.128.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75817926ec812241889208d1b190cadb7fedded4592a4bb01b8524babb9e4849"
-dependencies = [
- "cranelift-assembler-x64-meta 0.128.4",
- "cranelift-codegen-shared 0.128.4",
- "cranelift-srcgen 0.128.4",
- "heck 0.5.0",
- "pulley-interpreter 41.0.4",
+ "pulley-interpreter",
 ]
 
 [[package]]
@@ -1616,12 +1530,6 @@ name = "cranelift-codegen-shared"
 version = "0.124.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b187cbec77058579b47e8f75b1ce430b0d110df9c38d0fee2f8bd9801fd673"
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.128.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859158f87a59476476eda3884d883c32e08a143cf3d315095533b362a3250a63"
 
 [[package]]
 name = "cranelift-control"
@@ -1633,32 +1541,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-control"
-version = "0.128.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b65a9aec442d715cbf54d14548b8f395476c09cef7abe03e104a378291ab88"
-dependencies = [
- "arbitrary",
-]
-
-[[package]]
 name = "cranelift-entity"
 version = "0.124.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46e3a650a696c3f4c93bb869e7d219ba3abf6e247164aaf7f12dc918a1d52772"
 dependencies = [
- "cranelift-bitset 0.124.3",
- "serde",
- "serde_derive",
-]
-
-[[package]]
-name = "cranelift-entity"
-version = "0.128.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334c99a7e86060c24028732efd23bac84585770dcb752329c69f135d64f2fc1"
-dependencies = [
- "cranelift-bitset 0.128.4",
+ "cranelift-bitset",
  "serde",
  "serde_derive",
 ]
@@ -1669,19 +1557,7 @@ version = "0.124.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d48f516c004656a85747f6f8ccf6e23d8ec0a0a6dcf75ec85d6f2fa7e12c91"
 dependencies = [
- "cranelift-codegen 0.124.3",
- "log",
- "smallvec",
- "target-lexicon 0.13.5",
-]
-
-[[package]]
-name = "cranelift-frontend"
-version = "0.128.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ac6c095aa5b3e845d7ca3461e67e2b65249eb5401477a5ff9100369b745111"
-dependencies = [
- "cranelift-codegen 0.128.4",
+ "cranelift-codegen",
  "log",
  "smallvec",
  "target-lexicon 0.13.5",
@@ -1694,29 +1570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ce7761455ec4977010db897e9ad925200f08e435b9fa17575bd269ba174f33b"
 
 [[package]]
-name = "cranelift-isle"
-version = "0.128.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3d992870ed4f0f2e82e2175275cb3a123a46e9660c6558c46417b822c91fa"
-
-[[package]]
 name = "cranelift-native"
 version = "0.124.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42be1df38c4db6e19ba19d5ab8e65950c2865da0ad9e972a99ef224f1f77b8af"
 dependencies = [
- "cranelift-codegen 0.124.3",
- "libc",
- "target-lexicon 0.13.5",
-]
-
-[[package]]
-name = "cranelift-native"
-version = "0.128.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee32e36beaf80f309edb535274cfe0349e1c5cf5799ba2d9f42e828285c6b52e"
-dependencies = [
- "cranelift-codegen 0.128.4",
+ "cranelift-codegen",
  "libc",
  "target-lexicon 0.13.5",
 ]
@@ -1726,12 +1585,6 @@ name = "cranelift-srcgen"
 version = "0.124.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fee765d14f3f91dcba44c0e4b0eaece5f89024539b620af15a6aeec485b1170"
-
-[[package]]
-name = "cranelift-srcgen"
-version = "0.128.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903adeaf4938e60209a97b53a2e4326cd2d356aab9764a1934630204bae381c9"
 
 [[package]]
 name = "crc32c"
@@ -2430,7 +2283,7 @@ dependencies = [
  "url",
  "uuid",
  "wasi-common",
- "wasmtime 37.0.3",
+ "wasmtime",
  "wiggle",
 ]
 
@@ -2588,12 +2441,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -2856,20 +2703,6 @@ dependencies = [
  "debugid",
  "fxhash",
  "serde",
- "serde_json",
-]
-
-[[package]]
-name = "fxprof-processed-profile"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
-dependencies = [
- "bitflags 2.11.0",
- "debugid",
- "rustc-hash",
- "serde",
- "serde_derive",
  "serde_json",
 ]
 
@@ -4375,20 +4208,6 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "im-rc"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.4",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -5934,16 +5753,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.13.0",
-]
-
-[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6133,7 +5942,6 @@ dependencies = [
  "tempfile",
  "textwrap",
  "thiserror 2.0.18",
- "tikv-jemallocator",
  "tracing",
  "tracing-subscriber",
  "unicode-normalization",
@@ -6141,7 +5949,6 @@ dependencies = [
  "url",
  "uuid",
  "vergen-gix",
- "wasmtime 41.0.4",
 ]
 
 [[package]]
@@ -6525,22 +6332,10 @@ version = "37.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5c8a4c6db43cd896bcc33f316c2f449a89fbec962717e9097d88c9c82547ec0"
 dependencies = [
- "cranelift-bitset 0.124.3",
+ "cranelift-bitset",
  "log",
- "pulley-macros 37.0.3",
- "wasmtime-internal-math 37.0.3",
-]
-
-[[package]]
-name = "pulley-interpreter"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9812652c1feb63cf39f8780cecac154a32b22b3665806c733cd4072547233a4"
-dependencies = [
- "cranelift-bitset 0.128.4",
- "log",
- "pulley-macros 41.0.4",
- "wasmtime-internal-math 41.0.4",
+ "pulley-macros",
+ "wasmtime-internal-math",
 ]
 
 [[package]]
@@ -6548,17 +6343,6 @@ name = "pulley-macros"
 version = "37.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "573407df6287098f3e9ded7873a768156bc97c6939d077924d70416cb529bab6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "pulley-macros"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56000349b6896e3d44286eb9c330891237f40b27fd43c1ccc84547d0b463cb40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6794,15 +6578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -7714,19 +7489,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.13.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7912,16 +7674,6 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "slab"
@@ -9122,26 +8874,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
-]
-
-[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9720,12 +9452,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10016,7 +9742,7 @@ dependencies = [
  "system-interface",
  "thiserror 2.0.18",
  "tracing",
- "wasmtime 37.0.3",
+ "wasmtime",
  "wiggle",
  "windows-sys 0.60.2",
 ]
@@ -10099,27 +9825,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-compose"
-version = "0.243.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af801b6f36459023eaec63fdbaedad2fd5a4ab7dc74ecc110a8b5d375c5775e4"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "im-rc",
- "indexmap 2.13.0",
- "log",
- "petgraph",
- "serde",
- "serde_derive",
- "serde_yaml",
- "smallvec",
- "wasm-encoder 0.243.0",
- "wasmparser 0.243.0",
- "wat",
-]
-
-[[package]]
 name = "wasm-encoder"
 version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10127,16 +9832,6 @@ checksum = "5be00faa2b4950c76fe618c409d2c3ea5a3c9422013e079482d78544bb2d184c"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.239.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.243.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55db9c896d70bd9fa535ce83cd4e1f2ec3726b0edd2142079f594fc3be1cb35"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.243.0",
 ]
 
 [[package]]
@@ -10199,19 +9894,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.243.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d8db401b0528ec316dfbe579e6ab4152d61739cfe076706d2009127970159d"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
@@ -10245,17 +9927,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.243.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2b6035559e146114c29a909a3232928ee488d6507a1504d8934e8607b36d7b"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.243.0",
-]
-
-[[package]]
 name = "wasmtime"
 version = "37.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10269,7 +9940,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "encoding_rs",
- "fxprof-processed-profile 0.6.0",
+ "fxprof-processed-profile",
  "gimli",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
@@ -10281,7 +9952,7 @@ dependencies = [
  "object",
  "once_cell",
  "postcard",
- "pulley-interpreter 37.0.3",
+ "pulley-interpreter",
  "rayon",
  "rustix 1.1.4",
  "semver",
@@ -10292,79 +9963,22 @@ dependencies = [
  "target-lexicon 0.13.5",
  "wasm-encoder 0.239.0",
  "wasmparser 0.239.0",
- "wasmtime-environ 37.0.3",
+ "wasmtime-environ",
  "wasmtime-internal-asm-macros",
- "wasmtime-internal-cache 37.0.3",
- "wasmtime-internal-component-macro 37.0.3",
- "wasmtime-internal-component-util 37.0.3",
- "wasmtime-internal-cranelift 37.0.3",
- "wasmtime-internal-fiber 37.0.3",
- "wasmtime-internal-jit-debug 37.0.3",
- "wasmtime-internal-jit-icache-coherence 37.0.3",
- "wasmtime-internal-math 37.0.3",
- "wasmtime-internal-slab 37.0.3",
- "wasmtime-internal-unwinder 37.0.3",
- "wasmtime-internal-versioned-export-macros 37.0.3",
- "wasmtime-internal-winch 37.0.3",
+ "wasmtime-internal-cache",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-math",
+ "wasmtime-internal-slab",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-winch",
  "wat",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "wasmtime"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a83182bf04af87571b4c642300479501684f26bab5597f68f68cded5b098fd"
-dependencies = [
- "addr2line",
- "anyhow",
- "async-trait",
- "bitflags 2.11.0",
- "bumpalo",
- "cc",
- "cfg-if",
- "encoding_rs",
- "futures",
- "fxprof-processed-profile 0.8.1",
- "gimli",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "ittapi",
- "libc",
- "log",
- "mach2",
- "memfd",
- "object",
- "once_cell",
- "postcard",
- "pulley-interpreter 41.0.4",
- "rayon",
- "rustix 1.1.4",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "smallvec",
- "target-lexicon 0.13.5",
- "tempfile",
- "wasm-compose",
- "wasm-encoder 0.243.0",
- "wasmparser 0.243.0",
- "wasmtime-environ 41.0.4",
- "wasmtime-internal-cache 41.0.4",
- "wasmtime-internal-component-macro 41.0.4",
- "wasmtime-internal-component-util 41.0.4",
- "wasmtime-internal-cranelift 41.0.4",
- "wasmtime-internal-fiber 41.0.4",
- "wasmtime-internal-jit-debug 41.0.4",
- "wasmtime-internal-jit-icache-coherence 41.0.4",
- "wasmtime-internal-math 41.0.4",
- "wasmtime-internal-slab 41.0.4",
- "wasmtime-internal-unwinder 41.0.4",
- "wasmtime-internal-versioned-export-macros 41.0.4",
- "wasmtime-internal-winch 41.0.4",
- "wat",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10375,8 +9989,8 @@ checksum = "cb5f8069e3d2a235a8d273e58fc3b2088c730477fe8d5364495d4bf20ddbc45d"
 dependencies = [
  "anyhow",
  "cpp_demangle",
- "cranelift-bitset 0.124.3",
- "cranelift-entity 0.124.3",
+ "cranelift-bitset",
+ "cranelift-entity",
  "gimli",
  "indexmap 2.13.0",
  "log",
@@ -10390,35 +10004,8 @@ dependencies = [
  "target-lexicon 0.13.5",
  "wasm-encoder 0.239.0",
  "wasmparser 0.239.0",
- "wasmprinter 0.239.0",
- "wasmtime-internal-component-util 37.0.3",
-]
-
-[[package]]
-name = "wasmtime-environ"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb201c41aa23a3642365cfb2e4a183573d85127a3c9d528f56b9997c984541ab"
-dependencies = [
- "anyhow",
- "cpp_demangle",
- "cranelift-bitset 0.128.4",
- "cranelift-entity 0.128.4",
- "gimli",
- "indexmap 2.13.0",
- "log",
- "object",
- "postcard",
- "rustc-demangle",
- "semver",
- "serde",
- "serde_derive",
- "smallvec",
- "target-lexicon 0.13.5",
- "wasm-encoder 0.243.0",
- "wasmparser 0.243.0",
- "wasmprinter 0.243.0",
- "wasmtime-internal-component-util 41.0.4",
+ "wasmprinter",
+ "wasmtime-internal-component-util",
 ]
 
 [[package]]
@@ -10451,26 +10038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-internal-cache"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5b3069d1a67ba5969d0eb1ccd7e141367d4e713f4649aa90356c98e8f19bea"
-dependencies = [
- "base64 0.22.1",
- "directories-next",
- "log",
- "postcard",
- "rustix 1.1.4",
- "serde",
- "serde_derive",
- "sha2",
- "toml 0.9.12+spec-1.1.0",
- "wasmtime-environ 41.0.4",
- "windows-sys 0.61.2",
- "zstd",
-]
-
-[[package]]
 name = "wasmtime-internal-component-macro"
 version = "37.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10480,24 +10047,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "wasmtime-internal-component-util 37.0.3",
- "wasmtime-internal-wit-bindgen 37.0.3",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
  "wit-parser 0.239.0",
-]
-
-[[package]]
-name = "wasmtime-internal-component-macro"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c924400db7b6ca996fef1b23beb0f41d5c809836b1ec60fc25b4057e2d25d9b"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wasmtime-internal-component-util 41.0.4",
- "wasmtime-internal-wit-bindgen 41.0.4",
- "wit-parser 0.243.0",
 ]
 
 [[package]]
@@ -10507,12 +10059,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38171538c2612e9d07473f06fcf03d872fe1581e3f7c8587e04e2b2f8e47dcab"
 
 [[package]]
-name = "wasmtime-internal-component-util"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3f65daf4bf3d74ca2fbbe20af0589c42e2b398a073486451425d94fd4afef4"
-
-[[package]]
 name = "wasmtime-internal-cranelift"
 version = "37.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10520,51 +10066,24 @@ checksum = "4440d46baa6b12a40ba6beb1476ed023cee02e8fb45629d2666b9a852398c04b"
 dependencies = [
  "anyhow",
  "cfg-if",
- "cranelift-codegen 0.124.3",
- "cranelift-control 0.124.3",
- "cranelift-entity 0.124.3",
- "cranelift-frontend 0.124.3",
- "cranelift-native 0.124.3",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
  "gimli",
  "itertools",
  "log",
  "object",
- "pulley-interpreter 37.0.3",
+ "pulley-interpreter",
  "smallvec",
  "target-lexicon 0.13.5",
  "thiserror 2.0.18",
  "wasmparser 0.239.0",
- "wasmtime-environ 37.0.3",
- "wasmtime-internal-math 37.0.3",
- "wasmtime-internal-unwinder 37.0.3",
- "wasmtime-internal-versioned-export-macros 37.0.3",
-]
-
-[[package]]
-name = "wasmtime-internal-cranelift"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633e889cdae76829738db0114ab3b02fce51ea4a1cd9675a67a65fce92e8b418"
-dependencies = [
- "cfg-if",
- "cranelift-codegen 0.128.4",
- "cranelift-control 0.128.4",
- "cranelift-entity 0.128.4",
- "cranelift-frontend 0.128.4",
- "cranelift-native 0.128.4",
- "gimli",
- "itertools",
- "log",
- "object",
- "pulley-interpreter 41.0.4",
- "smallvec",
- "target-lexicon 0.13.5",
- "thiserror 2.0.18",
- "wasmparser 0.243.0",
- "wasmtime-environ 41.0.4",
- "wasmtime-internal-math 41.0.4",
- "wasmtime-internal-unwinder 41.0.4",
- "wasmtime-internal-versioned-export-macros 41.0.4",
+ "wasmtime-environ",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
@@ -10579,23 +10098,8 @@ dependencies = [
  "libc",
  "rustix 1.1.4",
  "wasmtime-internal-asm-macros",
- "wasmtime-internal-versioned-export-macros 37.0.3",
+ "wasmtime-internal-versioned-export-macros",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "wasmtime-internal-fiber"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb126adc5d0c72695cfb77260b357f1b81705a0f8fa30b3944e7c2219c17341"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "rustix 1.1.4",
- "wasmtime-environ 41.0.4",
- "wasmtime-internal-versioned-export-macros 41.0.4",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10607,19 +10111,7 @@ dependencies = [
  "cc",
  "object",
  "rustix 1.1.4",
- "wasmtime-internal-versioned-export-macros 37.0.3",
-]
-
-[[package]]
-name = "wasmtime-internal-jit-debug"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e66ff7f90a8002187691ff6237ffd09f954a0ebb9de8b2ff7f5c62632134120"
-dependencies = [
- "cc",
- "object",
- "rustix 1.1.4",
- "wasmtime-internal-versioned-export-macros 41.0.4",
+ "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
@@ -10635,31 +10127,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-internal-jit-icache-coherence"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b96df23179ae16d54fb3a420f84ffe4383ec9dd06fad3e5bc782f85f66e8e08"
-dependencies = [
- "anyhow",
- "cfg-if",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "wasmtime-internal-math"
 version = "37.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f9a2bff5db67f19f3d2f7b6ed4b4f67def9917111b824595eb84ef8e43c008e"
-dependencies = [
- "libm",
-]
-
-[[package]]
-name = "wasmtime-internal-math"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d1380926682b44c383e9a67f47e7a95e60c6d3fa8c072294dab2c7de6168a0"
 dependencies = [
  "libm",
 ]
@@ -10671,12 +10142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eafd48d67f1aae5a188c4842bee9de2c9f0e7a07626136e54223a0eb63bd4bca"
 
 [[package]]
-name = "wasmtime-internal-slab"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b63cbea1c0192c7feb7c0dfb35f47166988a3742f29f46b585ef57246c65764"
-
-[[package]]
 name = "wasmtime-internal-unwinder"
 version = "37.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10684,22 +10149,9 @@ checksum = "73cb01a1d8cd95583ac06cb82fc2ad465e893c3ed7d9765f750dfd9d2483a411"
 dependencies = [
  "anyhow",
  "cfg-if",
- "cranelift-codegen 0.124.3",
+ "cranelift-codegen",
  "log",
  "object",
-]
-
-[[package]]
-name = "wasmtime-internal-unwinder"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25c392c7e5fb891a7416e3c34cfbd148849271e8c58744fda875dde4bec4d6a"
-dependencies = [
- "cfg-if",
- "cranelift-codegen 0.128.4",
- "log",
- "object",
- "wasmtime-environ 41.0.4",
 ]
 
 [[package]]
@@ -10714,49 +10166,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-internal-versioned-export-macros"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f8b9796a3f0451a7b702508b303d654de640271ac80287176de222f187a237"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "wasmtime-internal-winch"
 version = "37.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cd3b2c652e93a8b3d6499f3299e46cb58db076a4477ddef594be9089f4cac38"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.124.3",
+ "cranelift-codegen",
  "gimli",
  "log",
  "object",
  "target-lexicon 0.13.5",
  "wasmparser 0.239.0",
- "wasmtime-environ 37.0.3",
- "wasmtime-internal-cranelift 37.0.3",
- "winch-codegen 37.0.3",
-]
-
-[[package]]
-name = "wasmtime-internal-winch"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0063e61f1d0b2c20e9cfc58361a6513d074a23c80b417aac3033724f51648a0"
-dependencies = [
- "cranelift-codegen 0.128.4",
- "gimli",
- "log",
- "object",
- "target-lexicon 0.13.5",
- "wasmparser 0.243.0",
- "wasmtime-environ 41.0.4",
- "wasmtime-internal-cranelift 41.0.4",
- "winch-codegen 41.0.4",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "winch-codegen",
 ]
 
 [[package]]
@@ -10770,19 +10194,6 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.13.0",
  "wit-parser 0.239.0",
-]
-
-[[package]]
-name = "wasmtime-internal-wit-bindgen"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "587699ca7cae16b4a234ffcc834f37e75675933d533809919b52975f5609e2ef"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "heck 0.5.0",
- "indexmap 2.13.0",
- "wit-parser 0.243.0",
 ]
 
 [[package]]
@@ -10960,7 +10371,7 @@ dependencies = [
  "bitflags 2.11.0",
  "thiserror 2.0.18",
  "tracing",
- "wasmtime 37.0.3",
+ "wasmtime",
  "wiggle-macro",
  "witx",
 ]
@@ -11029,37 +10440,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ece82b2b1513521f0bf419a61b4a6151bc99ee2906f3d51a75faf92c38c9b041"
 dependencies = [
  "anyhow",
- "cranelift-assembler-x64 0.124.3",
- "cranelift-codegen 0.124.3",
+ "cranelift-assembler-x64",
+ "cranelift-codegen",
  "gimli",
  "regalloc2",
  "smallvec",
  "target-lexicon 0.13.5",
  "thiserror 2.0.18",
  "wasmparser 0.239.0",
- "wasmtime-environ 37.0.3",
- "wasmtime-internal-cranelift 37.0.3",
- "wasmtime-internal-math 37.0.3",
-]
-
-[[package]]
-name = "winch-codegen"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55de3ac5b8bd71e5f6c87a9e511dd3ceb194bdb58183c6a7bf21cd8c0e46fbc"
-dependencies = [
- "anyhow",
- "cranelift-assembler-x64 0.128.4",
- "cranelift-codegen 0.128.4",
- "gimli",
- "regalloc2",
- "smallvec",
- "target-lexicon 0.13.5",
- "thiserror 2.0.18",
- "wasmparser 0.243.0",
- "wasmtime-environ 41.0.4",
- "wasmtime-internal-cranelift 41.0.4",
- "wasmtime-internal-math 41.0.4",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-math",
 ]
 
 [[package]]
@@ -11640,24 +11031,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.239.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.243.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df983a8608e513d8997f435bb74207bf0933d0e49ca97aa9d8a6157164b9b7fc"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.243.0",
 ]
 
 [[package]]

--- a/ai/memories/changelogs/202603131000-fix-windows-wasmtime-duplicate-symbol.md
+++ b/ai/memories/changelogs/202603131000-fix-windows-wasmtime-duplicate-symbol.md
@@ -1,0 +1,27 @@
+## 2026-03-13 10:00: fix: resolve Windows LNK1169 linker error caused by duplicate wasmtime versions
+
+**What changed:**
+- Disabled `default-features` on `pi_agent_rust` in `crates/peekoo-agent/Cargo.toml`, explicitly opting in to `image-resize`, `clipboard`, and `sqlite-sessions` features only -- excluding `wasm-host` and `jemalloc`.
+- Applied the same change to the dev-dependency in `crates/peekoo-agent-app/Cargo.toml`.
+
+**Why:**
+- Windows MSVC (`LINK.exe`) was failing with `LNK1169: one or more multiply defined symbols` due to two different versions of `wasmtime` being linked into the same binary:
+  - `wasmtime 37.0.3` via `peekoo-plugin-host` -> `extism 1.13`
+  - `wasmtime 41.0.4` via `peekoo-agent` -> `pi_agent_rust 0.1.7`
+- Both versions compile a C file (`gdbjit.c`) that defines the global C symbols `__jit_debug_descriptor` and `__jit_debug_register_code` without weak linkage on Windows, causing a fatal duplicate-symbol error.
+- On Linux/macOS these symbols use `__attribute__((weak))` so the linker silently deduplicates them -- the error only manifests on Windows.
+- `pi_agent_rust`'s `wasm-host` feature is the sole source of `wasmtime 41`. It enables WASM-based tool execution inside pi's agent runtime, which peekoo does not use -- the project has its own WASM plugin system via `peekoo-plugin-host` and `extism`.
+- Disabling `wasm-host` and `jemalloc` (which also has known Windows MSVC issues) removes `wasmtime 41` entirely from the dependency tree.
+
+**Architecture note:**
+- `peekoo-agent` uses `pi_agent_rust` purely for LLM session management (`AgentSessionHandle`, `create_agent_session`, prompt/subscribe/set_model). None of these code paths require `wasm-host`.
+- The WASM plugin system remains fully functional -- it runs through `peekoo-plugin-host` -> `extism` -> `wasmtime 37`, unchanged.
+
+**Files affected:**
+- `crates/peekoo-agent/Cargo.toml` (disabled default features on `pi_agent_rust`)
+- `crates/peekoo-agent-app/Cargo.toml` (same, dev-dependency)
+
+**Verification:**
+- `cargo check` -- clean, 0 errors
+- `cargo tree -i wasmtime` -- only `wasmtime v37.0.3` present; `wasmtime 41.0.4` fully removed
+- `cargo tree -d` -- no duplicate wasmtime crates

--- a/crates/peekoo-agent-app/Cargo.toml
+++ b/crates/peekoo-agent-app/Cargo.toml
@@ -25,5 +25,5 @@ tokio = { version = "1.50.0", features = ["sync"] }
 tokio-util = "0.7"
 
 [dev-dependencies]
-pi = { version = "0.1.7", package = "pi_agent_rust" }
+pi = { version = "0.1.7", package = "pi_agent_rust", default-features = false, features = ["image-resize", "clipboard", "sqlite-sessions"] }
 tokio = { version = "1.50.0", features = ["macros", "rt"] }

--- a/crates/peekoo-agent/Cargo.toml
+++ b/crates/peekoo-agent/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 peekoo-paths = { path = "../peekoo-paths" }
-pi = { version = "0.1.7", package = "pi_agent_rust" }
+pi = { version = "0.1.7", package = "pi_agent_rust", default-features = false, features = ["image-resize", "clipboard", "sqlite-sessions"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt"] }
 serde_json = "1"


### PR DESCRIPTION
## What changed

- Disabled `default-features` on `pi_agent_rust 0.1.7` in `crates/peekoo-agent/Cargo.toml` and `crates/peekoo-agent-app/Cargo.toml` (dev-dep), opting in to `image-resize`, `clipboard`, and `sqlite-sessions` only — excluding `wasm-host` and `jemalloc`.

**Root cause:** Two wasmtime versions were being linked into the same binary on Windows:
- `wasmtime 37.0.3` via `peekoo-plugin-host` → `extism 1.13`
- `wasmtime 41.0.4` via `peekoo-agent` → `pi_agent_rust 0.1.7` (`wasm-host` feature)

Both versions compile `gdbjit.c` which defines `__jit_debug_descriptor` and `__jit_debug_register_code` as non-weak global C symbols. On Windows MSVC, `LINK.exe` treats these as fatal duplicate-symbol errors (`LNK2005` → `LNK1169`). On Linux/macOS the linker silently picks one, so the error is Windows-only.

`pi_agent_rust`'s `wasm-host` feature is only needed for WASM-based tool execution inside pi's runtime. `peekoo-agent` uses pi exclusively for LLM session management — the project's own plugin system (`peekoo-plugin-host` + `extism`) handles all WASM execution. Disabling `wasm-host` (and `jemalloc`, which also has known Windows MSVC issues) removes `wasmtime 41` entirely from the dependency tree.

## Release notes

- [ ] Add at least one release-note label: `feature`, `fix`, `docs`, `test`, `chore`, `ci`, or `refactor`
- [ ] Use `skip-changelog` if this PR should be excluded from generated release notes

## Verification

- [x] `cargo check` — clean, 0 errors
- [x] `cargo tree -i wasmtime` — only `wasmtime v37.0.3` remains; `wasmtime 41.0.4` fully removed
- [x] `cargo tree -d` — no duplicate wasmtime crates