### PR TITLE
fix(peek-badge): show badges on startup and center badge UI

### DIFF
--- a/ai/memories/changelogs/202603131100-fix-peek-badge-startup-and-centering.md
+++ b/ai/memories/changelogs/202603131100-fix-peek-badge-startup-and-centering.md
@@ -1,0 +1,20 @@
+## 2026-03-13 11:00: fix: peek badge not showing on startup and off-center positioning
+
+**What changed:**
+- Added `ui_ready` gate to `PeekBadgeService`: a `ui_ready: bool` flag (default `false`) that prevents `take_if_changed()` from consuming badge data before the frontend has registered its event listener
+- Added `mark_ui_ready()` method on `PeekBadgeService` that flips the flag and re-marks buffered badges as dirty so they flush on the next tick
+- Exposed `mark_ui_ready()` through `AgentApplication` and added a `ui_ready` Tauri command
+- Frontend `usePeekBadge` hook now calls `invoke("ui_ready")` immediately after registering the `sprite:peek-badges` listener, unblocking backend badge emission
+- Replaced hardcoded `left: BADGE_LEFT` pixel positioning on `SpritePeekBadge` with `left: "50%"` + `marginLeft: -(BADGE_WIDTH / 2)` for robust centering regardless of actual container width; removed unused `SPRITE_WIDTH` import
+
+**Why:**
+- Race condition at startup: `plugin_init()` pushed badges during `AgentApplication::new()`, the background flush loop emitted `sprite:peek-badges` ~250ms later, but the React frontend hadn't mounted its event listener yet. The event was lost and the dirty flag cleared, so badges never appeared until the plugin was toggled off/on.
+- The `ui_ready` gate ensures badge data is retained until the frontend signals readiness, then flushed immediately.
+- The badge centering used a fixed pixel offset calculated from `SPRITE_WIDTH`, which could appear off-center depending on actual rendered window dimensions or display scaling.
+
+**Files affected:**
+- `crates/peekoo-notifications/src/peek_badge.rs` - Added `ui_ready` field, `mark_ui_ready()`, gated `take_if_changed()`
+- `crates/peekoo-agent-app/src/application.rs` - Exposed `mark_ui_ready()` delegate
+- `apps/desktop-tauri/src-tauri/src/lib.rs` - Added `ui_ready` Tauri command, registered in `generate_handler!`
+- `apps/desktop-ui/src/hooks/use-peek-badge.ts` - Added `invoke("ui_ready")` after listener registration
+- `apps/desktop-ui/src/components/sprite/SpritePeekBadge.tsx` - CSS centering fix, removed `SPRITE_WIDTH` import

--- a/apps/desktop-tauri/src-tauri/src/lib.rs
+++ b/apps/desktop-tauri/src-tauri/src/lib.rs
@@ -417,6 +417,18 @@ async fn dnd_set(active: bool, state: State<'_, AgentState>) -> Result<(), Strin
     Ok(())
 }
 
+/// Signal from the UI that it has mounted and is listening for events.
+///
+/// This unblocks the background flush loop so it can start emitting
+/// peek-badge updates.  Without this gate, badges pushed during plugin
+/// initialisation would be consumed and discarded before the frontend
+/// had registered its event listeners.
+#[tauri::command]
+async fn ui_ready(state: State<'_, AgentState>) -> Result<(), String> {
+    state.app.mark_ui_ready();
+    Ok(())
+}
+
 #[tauri::command]
 async fn plugin_enable(
     plugin_key: String,
@@ -627,6 +639,7 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .invoke_handler(tauri::generate_handler![
+            ui_ready,
             resize_sprite_window,
             greet,
             get_sprite_state,

--- a/apps/desktop-ui/src/components/sprite/SpritePeekBadge.tsx
+++ b/apps/desktop-ui/src/components/sprite/SpritePeekBadge.tsx
@@ -4,12 +4,10 @@ import {
   PEEK_BADGE_HEIGHT,
   PEEK_BADGE_PADDING,
   PEEK_BADGE_ROW_HEIGHT,
-  SPRITE_WIDTH,
 } from "@/lib/sprite-bubble-layout";
 import type { PeekBadgeItem } from "@/types/peek-badge";
 
 const BADGE_WIDTH = 180;
-const BADGE_LEFT = (SPRITE_WIDTH - BADGE_WIDTH) / 2;
 
 const ICON_MAP: Record<string, LucideIcon> = {
   droplet: Droplet,
@@ -79,7 +77,8 @@ export function SpritePeekBadge({
           className="pointer-events-auto absolute z-10 cursor-pointer rounded-xl border border-glass-border bg-glass/90 px-3 py-1.5 shadow-panel backdrop-blur-lg"
           style={{
             top: PEEK_BADGE_PADDING,
-            left: BADGE_LEFT,
+            left: "50%",
+            marginLeft: -(BADGE_WIDTH / 2),
             width: BADGE_WIDTH,
             maxHeight: expandedHeight,
           }}
@@ -99,7 +98,8 @@ export function SpritePeekBadge({
           className="pointer-events-auto absolute z-10 cursor-pointer rounded-xl border border-glass-border/60 bg-glass/80 px-3 shadow-panel/50 backdrop-blur-md"
           style={{
             top: PEEK_BADGE_PADDING,
-            left: BADGE_LEFT,
+            left: "50%",
+            marginLeft: -(BADGE_WIDTH / 2),
             width: BADGE_WIDTH,
             height: PEEK_BADGE_HEIGHT,
           }}

--- a/apps/desktop-ui/src/hooks/use-peek-badge.ts
+++ b/apps/desktop-ui/src/hooks/use-peek-badge.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
 import {
   PEEK_BADGES_EVENT,
   PeekBadgesPayloadSchema,
@@ -27,7 +28,9 @@ export function usePeekBadge() {
     at: Date.now(),
   });
 
-  // Listen for backend push events
+  // Listen for backend push events, then signal the backend that the UI is
+  // ready to receive badge updates.  This prevents the background flush loop
+  // from emitting (and discarding) badge data before this listener exists.
   useEffect(() => {
     const unlisten = listen(PEEK_BADGES_EVENT, (event) => {
       const parsed = PeekBadgesPayloadSchema.safeParse(event.payload);
@@ -39,6 +42,9 @@ export function usePeekBadge() {
         parsed.data.length > 0 ? prev % parsed.data.length : 0,
       );
     });
+
+    // Signal the backend that badge listeners are registered.
+    void invoke("ui_ready");
 
     return () => {
       unlisten.then((fn) => fn());

--- a/crates/peekoo-agent-app/src/application.rs
+++ b/crates/peekoo-agent-app/src/application.rs
@@ -329,6 +329,14 @@ impl AgentApplication {
         notifications
     }
 
+    /// Signal that the UI has mounted and is listening for badge events.
+    ///
+    /// Badges pushed before this call are retained and will be emitted on the
+    /// next background flush tick.
+    pub fn mark_ui_ready(&self) {
+        self.peek_badges.mark_ui_ready();
+    }
+
     /// Return the merged peek-badge list if any plugin pushed an update since the last call.
     pub fn take_peek_badges_if_changed(&self) -> Option<Vec<PeekBadgeItem>> {
         self.peek_badges.take_if_changed()

--- a/crates/peekoo-notifications/src/peek_badge.rs
+++ b/crates/peekoo-notifications/src/peek_badge.rs
@@ -25,6 +25,11 @@ pub struct PeekBadgeService {
 struct BadgeState {
     badges: HashMap<String, Vec<PeekBadgeItem>>,
     dirty: bool,
+    /// Whether the UI has signalled that it is mounted and listening for badge
+    /// events.  Until this is `true`, `take_if_changed` withholds data so the
+    /// background flush loop does not consume and discard badges before the
+    /// frontend can receive them.
+    ui_ready: bool,
 }
 
 impl Default for PeekBadgeService {
@@ -39,6 +44,7 @@ impl PeekBadgeService {
             inner: Mutex::new(BadgeState {
                 badges: HashMap::new(),
                 dirty: false,
+                ui_ready: false,
             }),
         }
     }
@@ -51,11 +57,26 @@ impl PeekBadgeService {
         }
     }
 
+    /// Signal that the UI has mounted and is listening for badge events.
+    ///
+    /// Any badges already buffered will be emitted on the next flush tick.
+    pub fn mark_ui_ready(&self) {
+        if let Ok(mut state) = self.inner.lock() {
+            state.ui_ready = true;
+            if !state.badges.is_empty() {
+                state.dirty = true;
+            }
+        }
+    }
+
     /// Return the merged badge list if anything changed since the last call.
-    /// Clears the dirty flag so subsequent calls return `None` until the next `set`.
+    ///
+    /// Returns `None` when the UI has not yet signalled readiness (via
+    /// [`mark_ui_ready`]) so that early badge pushes are not consumed and
+    /// discarded before the frontend can receive them.
     pub fn take_if_changed(&self) -> Option<Vec<PeekBadgeItem>> {
         let mut state = self.inner.lock().ok()?;
-        if !state.dirty {
+        if !state.ui_ready || !state.dirty {
             return None;
         }
         state.dirty = false;


### PR DESCRIPTION
## What changed

- Added a `ui_ready` gate to `PeekBadgeService` so the background flush loop withholds badge data until the frontend signals it has mounted its event listener. This fixes a startup race condition where badges pushed during plugin init were consumed and discarded before the React app could receive them.
- Added `ui_ready` Tauri command wired through `AgentApplication` -> `PeekBadgeService.mark_ui_ready()`.
- Frontend `usePeekBadge` hook now calls `invoke("ui_ready")` immediately after registering its `sprite:peek-badges` listener.
- Replaced hardcoded `left: BADGE_LEFT` pixel positioning on `SpritePeekBadge` with `left: 50%` + `marginLeft: -(BADGE_WIDTH / 2)` for robust centering regardless of actual container width.

## Release notes

- [x] Add at least one release-note label: `feature`, `fix`, `docs`, `test`, `chore`, `ci`, or `refactor`
- [ ] Use `skip-changelog` if this PR should be excluded from generated release notes

## Verification

- [x] Tests pass locally
- [x] `just check` clean
- [x] `just lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `just test` — all 126 tests pass