### PR TITLE
fix(sqlite): share single connection with WAL mode to fix Windows Access Denied

### DIFF
--- a/ai/memories/changelogs/202603131300-fix-windows-sqlite-access-denied.md
+++ b/ai/memories/changelogs/202603131300-fix-windows-sqlite-access-denied.md
@@ -1,0 +1,33 @@
+## 2026-03-13 13:00: fix: resolve Windows "Access Denied" (OS error 5) caused by dual SQLite connections
+
+**What changed:**
+- `AgentApplication::new()` now opens a single `rusqlite::Connection` to `peekoo.sqlite`, configures it with `PRAGMA journal_mode=WAL` and `PRAGMA busy_timeout=5000`, wraps it in `Arc<Mutex<Connection>>`, and passes that shared handle to both `SettingsService` and `create_plugin_registry`.
+- `SettingsStore` field changed from `Mutex<Connection>` to `Arc<Mutex<Connection>>`. Added `SettingsStore::with_conn(Arc<Mutex<Connection>>)` constructor; existing `from_path()` kept for test convenience (wraps in `Arc` internally). Extracted migration/seed logic into `run_migrations_and_seed()` helper.
+- `SettingsService` gained `with_conn(Arc<Mutex<Connection>>)` and `migrate_legacy_db()` public methods. `SettingsService::new()` kept for backward-compatible test usage.
+- `create_plugin_registry` now accepts `Arc<Mutex<Connection>>` instead of opening its own connection.
+- Legacy DB migration now runs **before** `Connection::open()` in the production bootstrap path, because `open()` creates the file as a side-effect, which would cause the migration to exit early (it skips when the target file already exists). This was a regression caught during code review.
+- Added regression test `legacy_migration_before_open_preserves_data` that proves both the correct ordering (migrate then open) and the broken ordering (open then migrate), ensuring the invariant is enforced going forward.
+
+**Why:**
+- On Windows, `AgentApplication::new()` was opening two independent `rusqlite::Connection` instances to the same `peekoo.sqlite` file: one via `SettingsService::new()` (at `settings/store.rs:38`) and another via `create_plugin_registry()` (at `application.rs:628`).
+- SQLite's default `DELETE` journal mode uses mandatory file locks on Windows (unlike advisory locks on POSIX). When both connections attempted writes concurrently, the second connection hit OS error 5 ("Access Denied" / "拒绝访问").
+- No `PRAGMA busy_timeout` was set, so contention failed immediately instead of retrying.
+- WAL mode allows concurrent readers and serialises writers gracefully. Combined with `busy_timeout=5000`, even future additional connections would tolerate brief contention instead of failing.
+
+**Critical ordering invariant:**
+- `SettingsService::migrate_legacy_db(&db_path)` **must** be called before `Connection::open(&db_path)` in the bootstrap path. `Connection::open` creates the file, and the migration exits early if the target file exists. Reversing the order silently drops legacy data on upgrade. This is enforced by the `legacy_migration_before_open_preserves_data` test.
+
+**Architecture note:**
+- `peekoo-plugin-host` (`PluginRegistry`, `PermissionStore`, `PluginStateStore`) already accepted `Arc<Mutex<Connection>>` -- no changes needed in that crate.
+- The shared connection carries all migrations (settings + plugin tables) since they live in the same `peekoo.sqlite` database via `0001_init.sql`, `0002_agent_settings.sql`, and `0003_provider_compat.sql`.
+- The `from_path()` / `new()` constructors remain available for test isolation where each test opens its own temporary database.
+
+**Files affected:**
+- `crates/peekoo-agent-app/src/application.rs` (single connection + pragmas, migration before open, pass to both subsystems)
+- `crates/peekoo-agent-app/src/settings/store.rs` (`conn` field -> `Arc<Mutex<Connection>>`, `with_conn` constructor, `run_migrations_and_seed` helper)
+- `crates/peekoo-agent-app/src/settings/mod.rs` (`migrate_legacy_db` + `with_conn` on `SettingsService`, regression test)
+
+**Verification:**
+- `cargo check` -- clean, 0 errors
+- `cargo clippy` -- clean, 0 warnings
+- `cargo test` -- all 137 tests pass across all crates (1 new regression test)

--- a/crates/peekoo-agent-app/src/application.rs
+++ b/crates/peekoo-agent-app/src/application.rs
@@ -57,9 +57,29 @@ pub struct AgentApplication {
 impl AgentApplication {
     pub fn new() -> Result<Self, String> {
         ensure_windows_pi_agent_env()?;
-        let settings = SettingsService::new()?;
+
+        // Open a single shared SQLite connection for the entire application.
+        // WAL mode allows concurrent readers and serialises writers gracefully,
+        // avoiding OS-level "Access Denied" (error 5) on Windows where SQLite
+        // uses mandatory file locks in the default DELETE journal mode.
+        //
+        // Legacy migration MUST run before Connection::open because open()
+        // creates the file as a side-effect, which would cause the migration
+        // to skip (it exits early when the target file already exists).
+        let db_path = peekoo_paths::peekoo_settings_db_path()?;
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| format!("Create db dir error: {e}"))?;
+        }
+        SettingsService::migrate_legacy_db(&db_path)?;
+        let conn =
+            Connection::open(&db_path).map_err(|e| format!("Open settings db error: {e}"))?;
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;")
+            .map_err(|e| format!("Set db pragmas error: {e}"))?;
+        let db_conn = Arc::new(Mutex::new(conn));
+
+        let settings = SettingsService::with_conn(Arc::clone(&db_conn))?;
         let (plugin_registry, notifications, notification_receiver, peek_badges) =
-            create_plugin_registry()?;
+            create_plugin_registry(db_conn)?;
         let shutdown_token = plugin_registry.scheduler().shutdown_token();
         install_discovered_plugins(&plugin_registry);
 
@@ -615,7 +635,9 @@ fn should_restore_agent(captured_generation: u64, current_generation: u64) -> bo
 }
 
 #[allow(clippy::type_complexity)]
-fn create_plugin_registry() -> Result<
+fn create_plugin_registry(
+    db_conn: Arc<Mutex<Connection>>,
+) -> Result<
     (
         Arc<PluginRegistry>,
         Arc<NotificationService>,
@@ -624,9 +646,6 @@ fn create_plugin_registry() -> Result<
     ),
     String,
 > {
-    let db_path = peekoo_paths::peekoo_settings_db_path()?;
-    let db_conn = Connection::open(&db_path).map_err(|e| format!("Open plugin db error: {e}"))?;
-
     let global_plugins_dir = peekoo_paths::peekoo_global_data_dir()?.join("plugins");
     if !global_plugins_dir.exists() {
         std::fs::create_dir_all(&global_plugins_dir)
@@ -639,7 +658,7 @@ fn create_plugin_registry() -> Result<
     let peek_badges = Arc::new(PeekBadgeService::new());
     let registry = Arc::new(PluginRegistry::new(
         vec![global_plugins_dir],
-        Arc::new(Mutex::new(db_conn)),
+        db_conn,
         scheduler,
         Arc::clone(&notifications),
         Arc::clone(&peek_badges),

--- a/crates/peekoo-agent-app/src/settings/mod.rs
+++ b/crates/peekoo-agent-app/src/settings/mod.rs
@@ -5,12 +5,14 @@ mod skills;
 mod store;
 
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use peekoo_agent::config::AgentServiceConfig;
 use peekoo_agent_auth::{OAuthFlowStatus, OAuthService};
 use peekoo_security::{
     FallbackSecretStore, FileSecretStore, KeyringSecretStore, SecretStore, SecretStoreError,
 };
+use rusqlite::Connection;
 use uuid::Uuid;
 
 use crate::settings::catalog::{
@@ -35,6 +37,33 @@ pub struct SettingsService {
 }
 
 impl SettingsService {
+    /// Migrate the legacy settings database to `target_db_path` if needed.
+    ///
+    /// This **must** be called before opening the SQLite connection because
+    /// `Connection::open` creates the file as a side-effect, which would
+    /// cause the migration to exit early (it skips when the target exists).
+    pub fn migrate_legacy_db(target_db_path: &Path) -> Result<(), String> {
+        migrate_legacy_settings_db_if_needed(target_db_path)
+    }
+
+    /// Create a `SettingsService` backed by an already-opened shared connection.
+    ///
+    /// The caller is responsible for:
+    /// 1. Running `migrate_legacy_db()` **before** opening the connection.
+    /// 2. Opening the connection and configuring PRAGMAs (WAL, busy_timeout).
+    pub fn with_conn(conn: Arc<Mutex<Connection>>) -> Result<Self, String> {
+        let store = SettingsStore::with_conn(conn)?;
+        let fallback_root = peekoo_paths::peekoo_global_data_dir()?.join("secrets");
+        Ok(Self {
+            store,
+            secret_store: Box::new(FallbackSecretStore::new(
+                Box::new(KeyringSecretStore::new("peekoo-desktop")),
+                Box::new(FileSecretStore::new(fallback_root)),
+            )),
+            oauth: OAuthService::new(),
+        })
+    }
+
     pub fn new() -> Result<Self, String> {
         let db_path = default_db_path()?;
         migrate_legacy_settings_db_if_needed(&db_path)?;
@@ -548,5 +577,76 @@ mod tests {
         assert_eq!(config.api_key.as_deref(), Some("oauth-fallback-token"));
 
         let _ = std::fs::remove_file(&db_path);
+    }
+
+    /// Regression test: legacy migration must run **before** `Connection::open`
+    /// because `open` creates the file, causing the migration to exit early.
+    ///
+    /// This mirrors the bootstrap order in `AgentApplication::new()`:
+    ///   1. `SettingsService::migrate_legacy_db(&db_path)`
+    ///   2. `Connection::open(&db_path)`
+    ///   3. `SettingsService::with_conn(conn)`
+    #[test]
+    fn legacy_migration_before_open_preserves_data() {
+        let temp = std::env::temp_dir().join(format!(
+            "peekoo-legacy-order-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let legacy_root = temp.join("legacy");
+        let target_root = temp.join("correct");
+        let broken_root = temp.join("broken");
+        std::fs::create_dir_all(&legacy_root).expect("create legacy root");
+        std::fs::create_dir_all(&target_root).expect("create target root");
+        std::fs::create_dir_all(&broken_root).expect("create broken root");
+
+        // Build a real legacy database with a custom provider/model.
+        let legacy_db = legacy_root.join("peekoo.sqlite");
+        {
+            let legacy_store =
+                store::SettingsStore::from_path(&legacy_db).expect("create legacy store");
+            legacy_store
+                .apply_patch(super::dto::AgentSettingsPatchDto {
+                    active_provider_id: Some("test-provider".into()),
+                    active_model_id: Some("test-model".into()),
+                    system_prompt: None,
+                    max_tool_iterations: None,
+                    skills: None,
+                })
+                .expect("seed legacy settings");
+        }
+
+        // ── Correct order: migrate THEN open ──────────────────────────
+        let correct_db = target_root.join("peekoo.sqlite");
+        migrate_settings_db_if_needed(&correct_db, Some(legacy_root.clone()))
+            .expect("migrate (correct order)");
+        let conn = Connection::open(&correct_db).expect("open after migration");
+        let db_conn = Arc::new(Mutex::new(conn));
+        let store = store::SettingsStore::with_conn(db_conn).expect("store from migrated db");
+        let settings = store.load_settings().expect("load migrated settings");
+        assert_eq!(
+            settings.active_provider_id, "test-provider",
+            "Correct order must preserve legacy provider"
+        );
+
+        // ── Broken order: open THEN migrate (the bug) ─────────────────
+        let broken_db = broken_root.join("peekoo.sqlite");
+        let _conn = Connection::open(&broken_db).expect("open before migration");
+        // File now exists, so migration will silently skip.
+        migrate_settings_db_if_needed(&broken_db, Some(legacy_root))
+            .expect("migrate (broken order)");
+        drop(_conn);
+        let conn2 = Connection::open(&broken_db).expect("reopen broken db");
+        let db_conn2 = Arc::new(Mutex::new(conn2));
+        let store2 = store::SettingsStore::with_conn(db_conn2).expect("store from empty db");
+        let settings2 = store2.load_settings().expect("load default settings");
+        assert_ne!(
+            settings2.active_provider_id, "test-provider",
+            "Broken order must NOT have legacy data (proves ordering matters)"
+        );
+
+        let _ = std::fs::remove_dir_all(&temp);
     }
 }

--- a/crates/peekoo-agent-app/src/settings/store.rs
+++ b/crates/peekoo-agent-app/src/settings/store.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use peekoo_persistence_sqlite::{
     MIGRATION_0001_INIT, MIGRATION_0002_AGENT_SETTINGS, MIGRATION_0003_PROVIDER_COMPAT,
@@ -25,10 +25,28 @@ const SQL_UPSERT_PROVIDER_AUTH: &str = concat!(
 use crate::settings::skills::discover_skills;
 
 pub(crate) struct SettingsStore {
-    conn: Mutex<Connection>,
+    conn: Arc<Mutex<Connection>>,
 }
 
 impl SettingsStore {
+    /// Create a `SettingsStore` backed by an already-opened shared connection.
+    ///
+    /// The caller is responsible for opening the connection and setting any
+    /// desired PRAGMAs (WAL mode, busy_timeout, etc.) before calling this.
+    /// Migrations and default seed rows are applied on the shared connection.
+    pub(crate) fn with_conn(conn: Arc<Mutex<Connection>>) -> Result<Self, String> {
+        {
+            let c = conn
+                .lock()
+                .map_err(|e| format!("Settings conn lock error: {e}"))?;
+            run_migrations_and_seed(&c)?;
+        }
+        Ok(Self { conn })
+    }
+
+    /// Convenience constructor that opens a new connection from a file path.
+    ///
+    /// Used by tests and the legacy `SettingsService::new()` code-path.
     pub(crate) fn from_path(path: &Path) -> Result<Self, String> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)
@@ -36,38 +54,10 @@ impl SettingsStore {
         }
 
         let conn = Connection::open(path).map_err(|e| format!("Open settings db error: {e}"))?;
-
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS _peekoo_migrations (id TEXT PRIMARY KEY)",
-            [],
-        )
-        .map_err(|e| format!("Create migrations table error: {e}"))?;
-
-        apply_migration_if_needed(&conn, "0001_init", "tasks", MIGRATION_0001_INIT)?;
-        apply_migration_if_needed(
-            &conn,
-            "0002_agent_settings",
-            "agent_settings",
-            MIGRATION_0002_AGENT_SETTINGS,
-        )?;
-        apply_migration_if_needed(
-            &conn,
-            "0003_provider_compat",
-            "agent_provider_configs",
-            MIGRATION_0003_PROVIDER_COMPAT,
-        )?;
-
-        conn.execute(
-            &format!(
-                "INSERT OR IGNORE INTO agent_settings (id, active_provider_id, active_model_id, system_prompt, max_tool_iterations, version, updated_at) VALUES (1, ?1, ?2, NULL, {}, 1, datetime('now'))",
-                DEFAULT_MAX_TOOL_ITERATIONS
-            ),
-            params![DEFAULT_PROVIDER, DEFAULT_MODEL],
-        )
-        .map_err(|e| format!("Insert default agent settings error: {e}"))?;
+        run_migrations_and_seed(&conn)?;
 
         Ok(Self {
-            conn: Mutex::new(conn),
+            conn: Arc::new(Mutex::new(conn)),
         })
     }
 
@@ -435,6 +425,39 @@ impl SettingsStore {
         .ok()
         .flatten()
     }
+}
+
+fn run_migrations_and_seed(conn: &Connection) -> Result<(), String> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS _peekoo_migrations (id TEXT PRIMARY KEY)",
+        [],
+    )
+    .map_err(|e| format!("Create migrations table error: {e}"))?;
+
+    apply_migration_if_needed(conn, "0001_init", "tasks", MIGRATION_0001_INIT)?;
+    apply_migration_if_needed(
+        conn,
+        "0002_agent_settings",
+        "agent_settings",
+        MIGRATION_0002_AGENT_SETTINGS,
+    )?;
+    apply_migration_if_needed(
+        conn,
+        "0003_provider_compat",
+        "agent_provider_configs",
+        MIGRATION_0003_PROVIDER_COMPAT,
+    )?;
+
+    conn.execute(
+        &format!(
+            "INSERT OR IGNORE INTO agent_settings (id, active_provider_id, active_model_id, system_prompt, max_tool_iterations, version, updated_at) VALUES (1, ?1, ?2, NULL, {}, 1, datetime('now'))",
+            DEFAULT_MAX_TOOL_ITERATIONS
+        ),
+        params![DEFAULT_PROVIDER, DEFAULT_MODEL],
+    )
+    .map_err(|e| format!("Insert default agent settings error: {e}"))?;
+
+    Ok(())
 }
 
 fn apply_migration_if_needed(


### PR DESCRIPTION
## What changed

- **Single shared SQLite connection**: `AgentApplication::new()` now opens one `rusqlite::Connection` to `peekoo.sqlite`, configures `PRAGMA journal_mode=WAL` and `PRAGMA busy_timeout=5000`, wraps it in `Arc<Mutex<Connection>>`, and passes it to both `SettingsService` and `create_plugin_registry`.
- **`SettingsStore` refactored**: `conn` field changed from `Mutex<Connection>` to `Arc<Mutex<Connection>>`. Added `with_conn()` constructor; `from_path()` kept for tests. Extracted `run_migrations_and_seed()` helper.
- **`SettingsService` refactored**: Added `with_conn()` and `migrate_legacy_db()` public methods. Legacy migration runs **before** `Connection::open()` to prevent the file-creation side-effect from skipping migration on upgrade.
- **`create_plugin_registry`** now accepts `Arc<Mutex<Connection>>` instead of opening its own.
- **Regression test** (`legacy_migration_before_open_preserves_data`): proves the migration ordering invariant -- migrate then open preserves legacy data, open then migrate does not.

### Root cause

On Windows, `AgentApplication::new()` was opening two independent `rusqlite::Connection` instances to the same `peekoo.sqlite` file. SQLite's default `DELETE` journal mode uses mandatory file locks on Windows (unlike advisory locks on POSIX). When both connections attempted writes, the second hit OS error 5 ("Access Denied" / 拒绝访问). No `busy_timeout` was set, so contention failed immediately.

## Release notes

- [x] Add at least one release-note label: `feature`, `fix`, `docs`, `test`, `chore`, `ci`, or `refactor`
- [ ] Use `skip-changelog` if this PR should be excluded from generated release notes

## Verification

- [x] Tests pass locally (`cargo test` -- 137 tests, all passing)
- [x] `cargo clippy` -- 0 warnings
- [x] `cargo check` -- 0 errors