### PR TITLE
fix(ci): set projectPath for tauri-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
+          projectPath: apps/desktop-tauri
           tagName: v__VERSION__
           releaseName: Peekoo v__VERSION__
           releaseBody: ${{ needs.release-notes.outputs.release_body }}


### PR DESCRIPTION
https://github.com/feed-mob/tracking_admin/issues/21942

## Summary
- Set `projectPath: apps/desktop-tauri` in the tauri-action configuration
- Fixes the `beforeBuildCommand` failing with "No such file or directory" error

## Problem
The tauri-action runs from the repository root by default, but the `beforeBuildCommand` in `tauri.conf.json` uses relative paths (`cd ../desktop-ui`) assuming it's running from `apps/desktop-tauri/src-tauri/`.

## Solution
Explicitly set `projectPath` so the relative path resolves correctly.

## Test plan
- [ ] Trigger a release workflow manually or via tag push
- [ ] Verify the beforeBuildCommand succeeds on all platforms