### PR TITLE
docs(macos): add install guide with Gatekeeper workaround

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
             --field tag_name="${GITHUB_REF_NAME}" \
             --field target_commitish="${GITHUB_SHA}" \
             --jq .body > release-notes.md
+          printf '\n---\n\n> macOS users: The macOS DMG is not yet notarized with Apple. After installing, open Terminal and run `xattr -cr /Applications/Peekoo.app` to allow the app to open. See the [macOS install guide](https://github.com/feed-mob/peekoo-ai/blob/master/docs/install-macos.md) for details.\n' >> release-notes.md
           {
             echo 'release_body<<EOF'
             cat release-notes.md

--- a/docs/install-macos.md
+++ b/docs/install-macos.md
@@ -1,0 +1,54 @@
+# Installing Peekoo on macOS
+
+## Download
+
+1. Go to the [latest GitHub Release](https://github.com/feed-mob/peekoo-ai/releases/latest).
+2. Download the `.dmg` file for macOS (Apple Silicon / ARM64).
+3. Open the DMG and drag **Peekoo** into your **Applications** folder.
+
+## Gatekeeper warning
+
+When you first open Peekoo you will see a macOS Gatekeeper warning:
+
+> "Peekoo" is damaged and can't be opened. You should move it to the Trash.
+
+This happens because the app is not yet notarized with Apple. The app is
+safe to use — macOS shows this warning for any app downloaded from the
+internet that has not been submitted to Apple's notarization service.
+
+## Fix: remove the quarantine attribute
+
+Open **Terminal** (Spotlight → type `Terminal`) and run:
+
+```bash
+xattr -cr /Applications/Peekoo.app
+```
+
+This strips the quarantine flag that macOS sets on downloaded files. After
+running the command, Peekoo will open normally.
+
+You only need to do this once per install. If you update Peekoo to a new
+version, you may need to run the command again.
+
+## Alternative fix (System Settings)
+
+On some macOS versions you can allow the app through System Settings instead:
+
+1. Try to open Peekoo (the warning appears).
+2. Open **System Settings → Privacy & Security**.
+3. Scroll down — you should see a message about Peekoo being blocked.
+4. Click **Open Anyway** and confirm.
+
+> **Note:** This method does not always work when macOS reports the app as
+> "damaged". If it does not appear in Privacy & Security, use the Terminal
+> command above.
+
+## Why does this happen?
+
+Apple requires developers to pay $99/year for an Apple Developer Program
+membership to sign and notarize apps. Until Peekoo enrolls in this program,
+macOS will flag the app as unverified. This does not mean the app is
+malicious — it means Apple has not reviewed it.
+
+Apps like VS Code, Slack, and Discord do not show this warning because their
+developers have paid for code signing and notarization.

--- a/docs/release.md
+++ b/docs/release.md
@@ -119,7 +119,7 @@ In GitHub:
 
 ## Notes
 
-- macOS signing and notarization are not configured yet, so users will still see Gatekeeper warnings.
+- macOS signing and notarization are not configured yet. Users must run `xattr -cr /Applications/Peekoo.app` after installing. See [docs/install-macos.md](install-macos.md) for details. Release notes include this instruction automatically.
 - Windows code signing is not configured yet, so SmartScreen warnings will still appear.
 - The updater only works after the public key placeholder is replaced and release artifacts are signed by the workflow.
 - Generated release notes come from GitHub's release notes API and are grouped by `.github/release.yml` labels.


### PR DESCRIPTION
## What changed

- Add `docs/install-macos.md` with step-by-step instructions for macOS users hitting the Gatekeeper "damaged and can't be opened" error
- Append a macOS install note (with `xattr -cr` command and link to the guide) to every GitHub Release body automatically
- Update `docs/release.md` to reference the new install guide instead of just noting that signing is not configured

## Release notes

- [x] Add at least one release-note label: `feature`, `fix`, `docs`, `test`, `chore`, `ci`, or `refactor`
- [ ] Use `skip-changelog` if this PR should be excluded from generated release notes

## Verification

- [x] No code changes — documentation and CI workflow text only
- [x] YAML syntax validated (no LSP errors in release.yml)