### PR TITLE
fix(windows): disable shadow on sprite and panel windows

### DIFF
--- a/apps/desktop-tauri/src-tauri/tauri.conf.json
+++ b/apps/desktop-tauri/src-tauri/tauri.conf.json
@@ -21,6 +21,7 @@
         "fullscreen": false,
         "center": true,
         "decorations": false,
+        "shadow": false,
         "transparent": true,
         "alwaysOnTop": true,
         "skipTaskbar": true

--- a/apps/desktop-ui/src/hooks/use-panel-windows.ts
+++ b/apps/desktop-ui/src/hooks/use-panel-windows.ts
@@ -60,6 +60,7 @@ export async function openPanelWindow(
     x: panelX,
     y: panelY,
     decorations: false,
+    shadow: false,
     transparent: true,
     alwaysOnTop: true,
     skipTaskbar: true,


### PR DESCRIPTION
## What changed

- Add `shadow: false` to the static `main` window in `tauri.conf.json`
- Add `shadow: false` to dynamically created panel windows in `use-panel-windows.ts`

Fixes compositor-drawn window borders visible on GNOME Wayland, where
`decorations: false` alone is insufficient to suppress the shadow/border.

## Release notes

- [ ] Add at least one release-note label: `feature`, `fix`, `docs`, `test`, `chore`, `ci`, or `refactor`
- [ ] Use `skip-changelog` if this PR should be excluded from generated release notes

## Verification

- [x] Tests pass locally