### PR TITLE
feat(ci): add workflow_dispatch support for publish-aur job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,18 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      publish_aur:
+        description: "Publish to AUR (requires a published release for the latest tag)"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
 
 jobs:
   release-notes:
-    if: github.event_name != 'release'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.publish_aur)
     runs-on: ubuntu-latest
     outputs:
       release_body: ${{ steps.notes.outputs.release_body }}
@@ -40,7 +45,7 @@ jobs:
 
   publish-tauri:
     needs: release-notes
-    if: github.event_name != 'release'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.publish_aur)
     strategy:
       fail-fast: false
       matrix:
@@ -101,14 +106,23 @@ jobs:
           args: ${{ matrix.args }}
 
   publish-aur:
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish_aur)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Extract version from release tag
+      - name: Resolve version
         id: version
-        run: echo "pkgver=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "pkgver=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            # Get the latest release tag
+            TAG=$(gh release view --json tagName --jq .tagName)
+            echo "pkgver=${TAG#v}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Compute AppImage SHA256 and patch PKGBUILD
         working-directory: packaging/aur


### PR DESCRIPTION
## Summary

- Add a `publish_aur` boolean input to the Release workflow for manually triggering AUR publishing
- When triggered manually, resolves the version from the latest GitHub release instead of the tag ref
- Scopes `release-notes` and `publish-tauri` to skip when only AUR publishing is requested

Usage:
```bash
gh workflow run release.yml -f publish_aur=true
```