### PR TITLE
fix(aur): prevent makepkg from stripping AppImage binary

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -7,6 +7,7 @@ url="https://github.com/feed-mob/peekoo-ai"
 license=('MIT')
 depends=('gtk3' 'webkit2gtk-4.1' 'libayatana-appindicator' 'libnotify')
 optdepends=('xdg-utils: open external links')
+options=('!strip')
 source=(
   "https://github.com/feed-mob/peekoo-ai/releases/download/v${pkgver}/Peekoo_${pkgver}_amd64.AppImage"
   'peekoo.desktop'


### PR DESCRIPTION
## Summary

- Add `options=('!strip')` to the AUR PKGBUILD to prevent `makepkg` from stripping the AppImage
- AppImages are ELF stubs with a squashfs filesystem appended — `strip` removes everything after the ELF sections, destroying the payload and reducing the ~96MB AppImage to ~0.9MB
- This was causing `This doesn't look like a squashfs image` errors when launching the app after AUR install