### PR TITLE
fix(aur): extract binary from AppImage instead of installing it directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,6 @@ jobs:
           pkgbuild: packaging/aur/PKGBUILD
           assets: |
             packaging/aur/peekoo.desktop
-            packaging/aur/peekoo.sh
             packaging/aur/peekoo.png
           updpkgsums: false
           commit_username: ${{ secrets.AUR_USERNAME }}

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -11,19 +11,21 @@ options=('!strip')
 source=(
   "https://github.com/feed-mob/peekoo-ai/releases/download/v${pkgver}/Peekoo_${pkgver}_amd64.AppImage"
   'peekoo.desktop'
-  'peekoo.sh'
   'peekoo.png'
 )
 sha256sums=(
   'REPLACE_WITH_APPIMAGE_SHA256'
   'SKIP'
   'SKIP'
-  'SKIP'
 )
 
+prepare() {
+  chmod +x "${srcdir}/Peekoo_${pkgver}_amd64.AppImage"
+  "${srcdir}/Peekoo_${pkgver}_amd64.AppImage" --appimage-extract
+}
+
 package() {
-  install -Dm755 "${srcdir}/Peekoo_${pkgver}_amd64.AppImage" "${pkgdir}/opt/peekoo/Peekoo.AppImage"
-  install -Dm755 "${srcdir}/peekoo.sh" "${pkgdir}/usr/bin/peekoo"
+  install -Dm755 "${srcdir}/squashfs-root/usr/bin/peekoo-desktop-tauri" "${pkgdir}/usr/bin/peekoo"
   install -Dm644 "${srcdir}/peekoo.desktop" "${pkgdir}/usr/share/applications/peekoo.desktop"
   install -Dm644 "${srcdir}/peekoo.png" "${pkgdir}/usr/share/pixmaps/peekoo.png"
 }

--- a/packaging/aur/peekoo.sh
+++ b/packaging/aur/peekoo.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-
-exec /opt/peekoo/Peekoo.AppImage "$@"


### PR DESCRIPTION
## Summary

- Extract the native `peekoo-desktop-tauri` binary from the AppImage during `prepare()` instead of installing the full AppImage
- The AppImage bundles Ubuntu 22.04 WebKitGTK and Mesa/EGL libraries which conflict with Arch Linux system GPU drivers, causing `EGL_BAD_ALLOC` errors and broken sprite rendering
- Remove the `peekoo.sh` wrapper script — the binary is now installed directly to `/usr/bin/peekoo`
- Remove `peekoo.sh` from the workflow assets list