### PR TITLE
chore(release): 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "peekoo-desktop-tauri"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dirs",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT"
-version = "0.1.1"
+version = "0.1.2"
 
 [profile.release]
 lto = true

--- a/apps/desktop-tauri/src-tauri/Cargo.toml
+++ b/apps/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peekoo-desktop-tauri"
-version = "0.1.1"
+version = "0.1.2"
 description = "Peekoo AI Desktop Pet - Tauri Version"
 edition = "2024"
 rust-version = "1.85"

--- a/apps/desktop-tauri/src-tauri/tauri.conf.json
+++ b/apps/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Peekoo",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "com.peekoo.desktop",
   "build": {
     "beforeDevCommand": "cd ../desktop-ui && bun run dev",

--- a/apps/desktop-ui/package.json
+++ b/apps/desktop-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "peekoo-desktop",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Peekoo AI Desktop Pet",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps version to 0.1.2 across all project files
- Updated: `Cargo.toml`, `Cargo.lock`, `apps/desktop-tauri/src-tauri/Cargo.toml`, `apps/desktop-tauri/src-tauri/tauri.conf.json`, `apps/desktop-ui/package.json`