### PR TITLE
feat(settings): add global settings panel with animated sprite selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5612,6 +5612,7 @@ dependencies = [
  "asupersync",
  "peekoo-agent",
  "peekoo-agent-auth",
+ "peekoo-app-settings",
  "peekoo-notifications",
  "peekoo-paths",
  "peekoo-persistence-sqlite",
@@ -5643,6 +5644,16 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "peekoo-app-settings"
+version = "0.1.0"
+dependencies = [
+ "peekoo-persistence-sqlite",
+ "rusqlite",
+ "serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "crates/peekoo-agent",
   "crates/peekoo-agent-auth",
   "crates/peekoo-agent-app",
+  "crates/peekoo-app-settings",
   "crates/peekoo-paths",
   "crates/peekoo-scheduler",
   "crates/peekoo-notifications",

--- a/ai/memories/changelogs/202603180000-feat-global-settings-sprite-selector.md
+++ b/ai/memories/changelogs/202603180000-feat-global-settings-sprite-selector.md
@@ -1,0 +1,43 @@
+## 2026-03-18 00:00 feat: global settings panel with animated sprite selector
+
+**What changed:**
+- Added new `peekoo-app-settings` crate with `AppSettingsStore` (key-value SQLite CRUD) and `AppSettingsService` (sprite-aware facade with validation); 8 unit tests
+- Added SQLite migration `0004_global_settings.sql` creating the `app_settings` key-value table (key, value, updated_at)
+- Wired `AppSettingsService` into `AgentApplication` in `peekoo-agent-app` alongside existing services, sharing the same SQLite connection
+- Added three Tauri commands: `app_settings_get`, `app_settings_set`, `app_settings_list_sprites`
+- Added a "Settings" item to the system tray menu (between Show/Hide Pet and Quit Peekoo) that emits an `open-settings` event to the frontend
+- Added `panel-settings` window (420×500) to the window registry and router
+- Created `SettingsView`, `SettingsPanel`, `useGlobalSettings` hook, and `SpriteSelector` component
+- `SpriteSelector` renders a 2-column grid of sprite cards; each card shows a live `SpriteAnimation` preview playing the idle animation at the sprite's native manifest scale, with a checkmark on the active selection
+- `Sprite.tsx` now loads the active sprite ID from `app_settings_get` on mount and reacts to `sprite:changed` events; default remains `dark-cat`
+- `SpriteView` listens for the `open-settings` tray event and opens/focuses the settings panel
+
+**Why:**
+- The active sprite was hardcoded to `"dark-cat"` with no way for users to switch pets
+- A dedicated global settings crate keeps app-level user preferences (sprite, future: language/theme) separate from agent concerns in `peekoo-agent-app`, following SRP
+- The key-value table design makes the settings layer trivially extensible for future preferences without schema migrations
+- Showing live animated previews in the selector gives users an accurate preview of how their chosen pet will actually look on the desktop
+
+**Files affected:**
+- `crates/peekoo-app-settings/Cargo.toml` (new)
+- `crates/peekoo-app-settings/src/lib.rs` (new)
+- `crates/peekoo-app-settings/src/dto.rs` (new)
+- `crates/peekoo-app-settings/src/store.rs` (new)
+- `crates/peekoo-app-settings/src/service.rs` (new)
+- `crates/persistence-sqlite/migrations/0004_global_settings.sql` (new)
+- `crates/persistence-sqlite/src/lib.rs`
+- `Cargo.toml`
+- `crates/peekoo-agent-app/Cargo.toml`
+- `crates/peekoo-agent-app/src/lib.rs`
+- `crates/peekoo-agent-app/src/application.rs`
+- `apps/desktop-tauri/src-tauri/src/lib.rs`
+- `apps/desktop-ui/src/types/global-settings.ts` (new)
+- `apps/desktop-ui/src/types/window.ts`
+- `apps/desktop-ui/src/routing/resolve-view.tsx`
+- `apps/desktop-ui/src/views/SettingsView.tsx` (new)
+- `apps/desktop-ui/src/features/settings/SettingsPanel.tsx` (new)
+- `apps/desktop-ui/src/features/settings/useGlobalSettings.ts` (new)
+- `apps/desktop-ui/src/features/settings/SpriteSelector.tsx` (new)
+- `apps/desktop-ui/src/components/sprite/Sprite.tsx`
+- `apps/desktop-ui/src/hooks/use-panel-windows.ts`
+- `apps/desktop-ui/src/views/SpriteView.tsx`

--- a/apps/desktop-tauri/src-tauri/src/lib.rs
+++ b/apps/desktop-tauri/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@ use peekoo_agent_app::{
     LastSessionDto, OauthCancelResponse, OauthStartResponse, OauthStatusRequest,
     OauthStatusResponse, PluginConfigFieldDto, PluginNotificationDto, PluginPanelDto,
     PluginSummaryDto, PomodoroSessionDto, ProviderAuthDto, ProviderConfigDto, ProviderRequest,
-    SetApiKeyRequest, SetProviderConfigRequest, StorePluginDto, TaskDto,
+    SetApiKeyRequest, SetProviderConfigRequest, SpriteInfo, StorePluginDto, TaskDto,
 };
 use serde::Serialize;
 use std::env;
@@ -32,6 +32,7 @@ use tauri_plugin_notification::NotificationExt;
 const MAIN_WINDOW_LABEL: &str = "main";
 const TRAY_ICON_ID: &str = "main-tray";
 const TRAY_TOGGLE_MENU_ID: &str = "toggle_visible";
+const TRAY_SETTINGS_MENU_ID: &str = "settings";
 const TRAY_QUIT_MENU_ID: &str = "quit";
 const TRAY_TOOLTIP: &str = "Peekoo";
 
@@ -98,6 +99,9 @@ fn toggle_main_window_visibility(app: &AppHandle) {
 fn handle_tray_menu_event(app: &AppHandle, menu_id: &str) {
     match menu_id {
         TRAY_TOGGLE_MENU_ID => toggle_main_window_visibility(app),
+        TRAY_SETTINGS_MENU_ID => {
+            let _ = app.emit("open-settings", ());
+        }
         TRAY_QUIT_MENU_ID => app.exit(0),
         _ => {}
     }
@@ -263,6 +267,31 @@ async fn agent_oauth_cancel(
     state: State<'_, AgentState>,
 ) -> Result<OauthCancelResponse, String> {
     state.app.oauth_cancel(req)
+}
+
+// ── Global app settings ─────────────────────────────────────────────────
+
+#[tauri::command]
+async fn app_settings_get(
+    state: State<'_, AgentState>,
+) -> Result<std::collections::HashMap<String, String>, String> {
+    state.app.get_app_settings()
+}
+
+#[tauri::command]
+async fn app_settings_set(
+    key: String,
+    value: String,
+    state: State<'_, AgentState>,
+) -> Result<(), String> {
+    state.app.set_app_setting(&key, &value)
+}
+
+#[tauri::command]
+async fn app_settings_list_sprites(
+    state: State<'_, AgentState>,
+) -> Result<Vec<SpriteInfo>, String> {
+    Ok(state.app.list_sprites())
 }
 
 #[tauri::command]
@@ -611,6 +640,7 @@ pub fn run() {
         .setup(|app| {
             let tray_menu = MenuBuilder::new(app)
                 .text(TRAY_TOGGLE_MENU_ID, "Show/Hide Pet")
+                .text(TRAY_SETTINGS_MENU_ID, "Settings")
                 .separator()
                 .text(TRAY_QUIT_MENU_ID, "Quit Peekoo")
                 .build()?;
@@ -733,6 +763,9 @@ pub fn run() {
             agent_oauth_start,
             agent_oauth_status,
             agent_oauth_cancel,
+            app_settings_get,
+            app_settings_set,
+            app_settings_list_sprites,
             create_task,
             pomodoro_start,
             pomodoro_pause,

--- a/apps/desktop-ui/src/components/sprite/Sprite.tsx
+++ b/apps/desktop-ui/src/components/sprite/Sprite.tsx
@@ -1,4 +1,6 @@
 import { useState, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import SpriteAnimation from "./SpriteAnimation";
 import type { AnimationType, SpriteState, SpriteManifest } from "@/types/sprite";
 
@@ -31,6 +33,8 @@ const ANIMATION_TO_TYPE: Record<string, AnimationType> = {
   dragging: "dragging",
 };
 
+const DEFAULT_SPRITE_ID = "dark-cat";
+
 interface SpriteProps {
   state?: SpriteState;
   animationOverride?: AnimationType | null;
@@ -43,8 +47,29 @@ export function Sprite({ state, animationOverride = null }: SpriteProps) {
     animation: "bounce",
   };
 
-  const [activeSpriteId] = useState("dark-cat");
+  const [activeSpriteId, setActiveSpriteId] = useState(DEFAULT_SPRITE_ID);
   const [manifest, setManifest] = useState<SpriteManifest | null>(null);
+
+  // Load active sprite ID from global settings on mount
+  useEffect(() => {
+    invoke<Record<string, string>>("app_settings_get")
+      .then((settings) => {
+        if (settings.active_sprite_id) {
+          setActiveSpriteId(settings.active_sprite_id);
+        }
+      })
+      .catch((err) => console.error("Failed to load active sprite setting", err));
+  }, []);
+
+  // Listen for sprite changes from the settings panel
+  useEffect(() => {
+    const unlisten = listen<{ id: string }>("sprite:changed", (event) => {
+      setActiveSpriteId(event.payload.id);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
 
   // Load sprite manifest
   useEffect(() => {

--- a/apps/desktop-ui/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop-ui/src/features/settings/SettingsPanel.tsx
@@ -1,0 +1,34 @@
+import { useGlobalSettings } from "./useGlobalSettings";
+import { SpriteSelector } from "./SpriteSelector";
+
+export function SettingsPanel() {
+  const { activeSpriteId, sprites, loading, error, setActiveSpriteId } = useGlobalSettings();
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-32 text-text-muted text-sm">
+        Loading settings...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center h-32 text-danger text-sm">
+        Failed to load settings: {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <SpriteSelector
+        sprites={sprites}
+        activeSpriteId={activeSpriteId}
+        onSelect={setActiveSpriteId}
+      />
+
+      {/* Future sections (language, theme, etc.) can be added here */}
+    </div>
+  );
+}

--- a/apps/desktop-ui/src/features/settings/SpriteSelector.tsx
+++ b/apps/desktop-ui/src/features/settings/SpriteSelector.tsx
@@ -1,0 +1,78 @@
+import { useState, useEffect } from "react";
+import { Check } from "lucide-react";
+import SpriteAnimation from "@/components/sprite/SpriteAnimation";
+import type { SpriteInfo } from "@/types/global-settings";
+import type { SpriteManifest } from "@/types/sprite";
+import { cn } from "@/lib/utils";
+
+interface SpriteSelectorProps {
+  sprites: SpriteInfo[];
+  activeSpriteId: string | null;
+  onSelect: (spriteId: string) => void;
+}
+
+function SpritePreview({ spriteId }: { spriteId: string }) {
+  const [manifest, setManifest] = useState<SpriteManifest | null>(null);
+
+  useEffect(() => {
+    fetch(`/sprites/${spriteId}/manifest.json`)
+      .then((res) => res.json())
+      .then((data: SpriteManifest) => setManifest(data))
+      .catch((err) => console.error(`Failed to load manifest for ${spriteId}`, err));
+  }, [spriteId]);
+
+  if (!manifest) {
+    return <div className="w-full h-24 flex items-center justify-center text-text-muted text-xs">Loading...</div>;
+  }
+
+  return (
+    <div className="flex items-center justify-center h-24">
+      <SpriteAnimation
+        animation="idle"
+        frameRate={manifest.frameRate || 8}
+        scale={manifest.scale ?? 0.40}
+        chromaKey={manifest.chromaKey}
+        imageSrc={`/sprites/${spriteId}/${manifest.image}`}
+        columns={manifest.layout.columns}
+        rows={manifest.layout.rows}
+        pixelArt={manifest.chromaKey.pixelArt}
+      />
+    </div>
+  );
+}
+
+export function SpriteSelector({ sprites, activeSpriteId, onSelect }: SpriteSelectorProps) {
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-semibold text-text-primary">Pet Sprite</h3>
+      <div className="grid grid-cols-2 gap-3">
+        {sprites.map((sprite) => {
+          const isActive = sprite.id === activeSpriteId;
+          return (
+            <button
+              key={sprite.id}
+              onClick={() => onSelect(sprite.id)}
+              className={cn(
+                "relative flex flex-col items-center gap-2 p-3 rounded-xl border transition-all cursor-pointer",
+                isActive
+                  ? "border-glow-green bg-muted-green/50 shadow-glow-green"
+                  : "border-glass-border bg-glass hover:bg-space-overlay hover:border-text-muted",
+              )}
+            >
+              {isActive && (
+                <div className="absolute top-2 right-2 w-5 h-5 rounded-full bg-glow-green flex items-center justify-center">
+                  <Check size={12} className="text-white" />
+                </div>
+              )}
+              <SpritePreview spriteId={sprite.id} />
+              <div className="text-center">
+                <p className="text-xs font-medium text-text-primary">{sprite.name}</p>
+                <p className="text-[10px] text-text-muted leading-tight mt-0.5">{sprite.description}</p>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop-ui/src/features/settings/useGlobalSettings.ts
+++ b/apps/desktop-ui/src/features/settings/useGlobalSettings.ts
@@ -1,0 +1,69 @@
+import { useState, useEffect, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { emit } from "@tauri-apps/api/event";
+import type { SpriteInfo } from "@/types/global-settings";
+
+interface GlobalSettingsState {
+  activeSpriteId: string | null;
+  sprites: SpriteInfo[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function useGlobalSettings() {
+  const [state, setState] = useState<GlobalSettingsState>({
+    activeSpriteId: null,
+    sprites: [],
+    loading: true,
+    error: null,
+  });
+
+  const load = useCallback(async () => {
+    try {
+      const [settings, sprites] = await Promise.all([
+        invoke<Record<string, string>>("app_settings_get"),
+        invoke<SpriteInfo[]>("app_settings_list_sprites"),
+      ]);
+      setState({
+        activeSpriteId: settings.active_sprite_id ?? "dark-cat",
+        sprites,
+        loading: false,
+        error: null,
+      });
+    } catch (err) {
+      setState((prev) => ({
+        ...prev,
+        loading: false,
+        error: String(err),
+      }));
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const setActiveSpriteId = useCallback(
+    async (spriteId: string) => {
+      try {
+        await invoke("app_settings_set", {
+          key: "active_sprite_id",
+          value: spriteId,
+        });
+        setState((prev) => ({ ...prev, activeSpriteId: spriteId }));
+        await emit("sprite:changed", { id: spriteId });
+      } catch (err) {
+        setState((prev) => ({ ...prev, error: String(err) }));
+      }
+    },
+    [],
+  );
+
+  return {
+    activeSpriteId: state.activeSpriteId,
+    sprites: state.sprites,
+    loading: state.loading,
+    error: state.error,
+    setActiveSpriteId,
+  };
+}

--- a/apps/desktop-ui/src/hooks/use-panel-windows.ts
+++ b/apps/desktop-ui/src/hooks/use-panel-windows.ts
@@ -19,6 +19,7 @@ const INITIAL_STATE: PanelWindowStates = {
   "panel-tasks": { isOpen: false },
   "panel-pomodoro": { isOpen: false },
   "panel-plugins": { isOpen: false },
+  "panel-settings": { isOpen: false },
 };
 
 const PANEL_OFFSET_X = 20;

--- a/apps/desktop-ui/src/routing/resolve-view.tsx
+++ b/apps/desktop-ui/src/routing/resolve-view.tsx
@@ -7,6 +7,7 @@ const TasksView = lazy(() => import("@/views/TasksView"));
 const PomodoroView = lazy(() => import("@/views/PomodoroView"));
 const PluginsView = lazy(() => import("@/views/PluginsView"));
 const PluginPanelView = lazy(() => import("@/views/PluginPanelView"));
+const SettingsView = lazy(() => import("@/views/SettingsView"));
 
 function UnknownView({ label }: { label: string }) {
   return (
@@ -38,6 +39,8 @@ function viewForLabel(label: string) {
       return <PomodoroView />;
     case "panel-plugins":
       return <PluginsView />;
+    case "panel-settings":
+      return <SettingsView />;
   }
 }
 

--- a/apps/desktop-ui/src/types/global-settings.ts
+++ b/apps/desktop-ui/src/types/global-settings.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const SpriteInfoSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+});
+export type SpriteInfo = z.infer<typeof SpriteInfoSchema>;
+
+export const GlobalSettingsSchema = z.record(z.string(), z.string());
+export type GlobalSettings = z.infer<typeof GlobalSettingsSchema>;

--- a/apps/desktop-ui/src/types/window.ts
+++ b/apps/desktop-ui/src/types/window.ts
@@ -5,6 +5,7 @@ export const BUILTIN_PANEL_LABELS = [
   "panel-tasks",
   "panel-pomodoro",
   "panel-plugins",
+  "panel-settings",
 ] as const;
 
 export const WindowLabelSchema = z.string().refine(
@@ -52,5 +53,11 @@ export const PANEL_WINDOW_CONFIGS: Record<string, PanelWindowConfig> = {
     title: "Peekoo Plugins",
     width: 500,
     height: 600,
+  },
+  "panel-settings": {
+    label: "panel-settings",
+    title: "Peekoo Settings",
+    width: 420,
+    height: 500,
   },
 };

--- a/apps/desktop-ui/src/views/SettingsView.tsx
+++ b/apps/desktop-ui/src/views/SettingsView.tsx
@@ -1,0 +1,10 @@
+import { PanelShell } from "@/components/panels/PanelShell";
+import { SettingsPanel } from "@/features/settings/SettingsPanel";
+
+export default function SettingsView() {
+  return (
+    <PanelShell title="Settings">
+      <SettingsPanel />
+    </PanelShell>
+  );
+}

--- a/apps/desktop-ui/src/views/SpriteView.tsx
+++ b/apps/desktop-ui/src/views/SpriteView.tsx
@@ -112,6 +112,16 @@ export default function SpriteView() {
 
   useSpriteReactions({ onMoodChange: handleMoodChange });
 
+  // Open settings panel when the tray menu "Settings" item is clicked
+  useEffect(() => {
+    const unlisten = listen("open-settings", () => {
+      void togglePanel("panel-settings");
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [togglePanel]);
+
   // Determine effective sprite state with priority:
   // 1. moodOverride (reactions, reminders) - highest priority
   // 2. randomState (idle state manager) - low priority

--- a/crates/peekoo-agent-app/Cargo.toml
+++ b/crates/peekoo-agent-app/Cargo.toml
@@ -9,6 +9,7 @@ plugin-runtime = ["peekoo-plugin-host/plugin-runtime"]
 
 [dependencies]
 peekoo-agent = { path = "../peekoo-agent" }
+peekoo-app-settings = { path = "../peekoo-app-settings" }
 peekoo-agent-auth = { path = "../peekoo-agent-auth" }
 peekoo-productivity-domain = { path = "../peekoo-productivity-domain" }
 peekoo-persistence-sqlite = { path = "../persistence-sqlite" }

--- a/crates/peekoo-agent-app/src/application.rs
+++ b/crates/peekoo-agent-app/src/application.rs
@@ -10,6 +10,7 @@ use peekoo_agent::AgentEvent;
 use peekoo_agent::PluginToolProvider;
 use peekoo_agent::config::AgentServiceConfig;
 use peekoo_agent::service::AgentService;
+use peekoo_app_settings::{AppSettingsService, SpriteInfo};
 use peekoo_notifications::{
     MoodReaction, MoodReactionService, Notification, NotificationService, PeekBadgeItem,
     PeekBadgeService,
@@ -38,6 +39,7 @@ use crate::workspace_bootstrap::ensure_agent_workspace;
 pub struct AgentApplication {
     agent: Mutex<Option<AgentService>>,
     settings: SettingsService,
+    app_settings: AppSettingsService,
     productivity: ProductivityService,
     plugin_registry: Arc<PluginRegistry>,
     plugin_tools: Arc<PluginToolProviderImpl>,
@@ -82,6 +84,7 @@ impl AgentApplication {
         let db_conn = Arc::new(Mutex::new(conn));
 
         let settings = SettingsService::with_conn(Arc::clone(&db_conn))?;
+        let app_settings = AppSettingsService::with_conn(Arc::clone(&db_conn))?;
         let (plugin_registry, notifications, notification_receiver, peek_badges, mood_reactions) =
             create_plugin_registry(db_conn)?;
         let shutdown_token = plugin_registry.scheduler().shutdown_token();
@@ -97,6 +100,7 @@ impl AgentApplication {
         Ok(Self {
             agent: Mutex::new(None),
             settings,
+            app_settings,
             productivity: ProductivityService::new(),
             plugin_tools: Arc::new(PluginToolProviderImpl::new(Arc::clone(&plugin_registry))),
             plugin_registry,
@@ -249,6 +253,30 @@ impl AgentApplication {
     pub fn oauth_cancel(&self, req: OauthStatusRequest) -> Result<OauthCancelResponse, String> {
         self.settings.cancel_oauth(req)
     }
+
+    // ── Global app settings ────────────────────────────────────────────
+
+    pub fn get_active_sprite_id(&self) -> Result<String, String> {
+        self.app_settings.get_active_sprite_id()
+    }
+
+    pub fn set_active_sprite_id(&self, sprite_id: &str) -> Result<(), String> {
+        self.app_settings.set_active_sprite_id(sprite_id)
+    }
+
+    pub fn list_sprites(&self) -> Vec<SpriteInfo> {
+        self.app_settings.list_sprites()
+    }
+
+    pub fn get_app_settings(&self) -> Result<std::collections::HashMap<String, String>, String> {
+        self.app_settings.get_all()
+    }
+
+    pub fn set_app_setting(&self, key: &str, value: &str) -> Result<(), String> {
+        self.app_settings.set(key, value)
+    }
+
+    // ── Productivity ────────────────────────────────────────────────────
 
     pub fn create_task(&self, title: &str, priority: &str) -> Result<TaskDto, String> {
         self.productivity.create_task(title, priority)

--- a/crates/peekoo-agent-app/src/lib.rs
+++ b/crates/peekoo-agent-app/src/lib.rs
@@ -8,6 +8,7 @@ mod workspace_bootstrap;
 
 pub use application::AgentApplication;
 pub use conversation::{LastSessionDto, SessionMessageDto};
+pub use peekoo_app_settings::{AppSettingsService, SpriteInfo};
 pub use peekoo_notifications::PeekBadgeItem;
 pub use peekoo_plugin_store::{PluginSource, StorePluginDto};
 pub use plugin::{PluginConfigFieldDto, PluginNotificationDto, PluginPanelDto, PluginSummaryDto};

--- a/crates/peekoo-app-settings/Cargo.toml
+++ b/crates/peekoo-app-settings/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "peekoo-app-settings"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+peekoo-persistence-sqlite = { path = "../persistence-sqlite" }
+rusqlite = { version = "0.38" }
+serde = { version = "1", features = ["derive"] }
+thiserror = "1"

--- a/crates/peekoo-app-settings/src/dto.rs
+++ b/crates/peekoo-app-settings/src/dto.rs
@@ -1,0 +1,10 @@
+use serde::Serialize;
+
+/// Summary of an available sprite that can be selected by the user.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpriteInfo {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+}

--- a/crates/peekoo-app-settings/src/lib.rs
+++ b/crates/peekoo-app-settings/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod dto;
+pub mod service;
+mod store;
+
+pub use dto::SpriteInfo;
+pub use service::AppSettingsService;

--- a/crates/peekoo-app-settings/src/service.rs
+++ b/crates/peekoo-app-settings/src/service.rs
@@ -1,0 +1,130 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use rusqlite::Connection;
+
+use crate::dto::SpriteInfo;
+use crate::store::AppSettingsStore;
+
+const SETTING_ACTIVE_SPRITE_ID: &str = "active_sprite_id";
+const DEFAULT_SPRITE_ID: &str = "dark-cat";
+
+/// Internal static representation of built-in sprites.
+///
+/// When user-added sprites are supported in the future this list can be
+/// extended dynamically by scanning a sprites directory.
+struct BuiltinSprite {
+    id: &'static str,
+    name: &'static str,
+    description: &'static str,
+}
+
+const BUILTIN_SPRITES: &[BuiltinSprite] = &[
+    BuiltinSprite {
+        id: "dark-cat",
+        name: "Dark Cat",
+        description: "Default dark-themed AI pet.",
+    },
+    BuiltinSprite {
+        id: "cute-dog",
+        name: "Cute Dog",
+        description: "A cute alternative AI pet.",
+    },
+];
+
+/// Application-level settings service for user preferences.
+///
+/// Manages global settings such as the active sprite. Backed by a key-value
+/// SQLite table (`app_settings`).
+pub struct AppSettingsService {
+    store: AppSettingsStore,
+}
+
+impl AppSettingsService {
+    /// Create a service using a shared database connection.
+    pub fn with_conn(conn: Arc<Mutex<Connection>>) -> Result<Self, String> {
+        let store = AppSettingsStore::with_conn(conn)?;
+        Ok(Self { store })
+    }
+
+    /// Return the currently selected sprite ID, falling back to the default.
+    pub fn get_active_sprite_id(&self) -> Result<String, String> {
+        Ok(self
+            .store
+            .get(SETTING_ACTIVE_SPRITE_ID)?
+            .unwrap_or_else(|| DEFAULT_SPRITE_ID.to_string()))
+    }
+
+    /// Set the active sprite.
+    ///
+    /// Returns an error if `sprite_id` does not match any known sprite.
+    pub fn set_active_sprite_id(&self, sprite_id: &str) -> Result<(), String> {
+        let valid = BUILTIN_SPRITES.iter().any(|s| s.id == sprite_id);
+        if !valid {
+            return Err(format!("Unknown sprite: {sprite_id}"));
+        }
+        self.store.set(SETTING_ACTIVE_SPRITE_ID, sprite_id)
+    }
+
+    /// List all available sprites.
+    pub fn list_sprites(&self) -> Vec<SpriteInfo> {
+        BUILTIN_SPRITES
+            .iter()
+            .map(|s| SpriteInfo {
+                id: s.id.to_string(),
+                name: s.name.to_string(),
+                description: s.description.to_string(),
+            })
+            .collect()
+    }
+
+    /// Return all settings as a key-value map.
+    pub fn get_all(&self) -> Result<HashMap<String, String>, String> {
+        self.store.get_all()
+    }
+
+    /// Set a single setting by key.
+    pub fn set(&self, key: &str, value: &str) -> Result<(), String> {
+        self.store.set(key, value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_service() -> AppSettingsService {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        AppSettingsService::with_conn(Arc::new(Mutex::new(conn))).expect("service")
+    }
+
+    #[test]
+    fn default_sprite_is_dark_cat() {
+        let svc = test_service();
+        assert_eq!(svc.get_active_sprite_id().unwrap(), "dark-cat");
+    }
+
+    #[test]
+    fn set_valid_sprite_succeeds() {
+        let svc = test_service();
+        svc.set_active_sprite_id("cute-dog").unwrap();
+        assert_eq!(svc.get_active_sprite_id().unwrap(), "cute-dog");
+    }
+
+    #[test]
+    fn set_invalid_sprite_returns_error() {
+        let svc = test_service();
+        let result = svc.set_active_sprite_id("unknown-sprite");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown sprite"));
+    }
+
+    #[test]
+    fn list_sprites_returns_builtins() {
+        let svc = test_service();
+        let sprites = svc.list_sprites();
+        assert_eq!(sprites.len(), 2);
+        assert_eq!(sprites[0].id, "dark-cat");
+        assert_eq!(sprites[1].id, "cute-dog");
+    }
+}

--- a/crates/peekoo-app-settings/src/store.rs
+++ b/crates/peekoo-app-settings/src/store.rs
@@ -1,0 +1,125 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use peekoo_persistence_sqlite::MIGRATION_0004_GLOBAL_SETTINGS;
+use rusqlite::{Connection, OptionalExtension, params};
+
+/// Key-value store backed by the `app_settings` SQLite table.
+pub(crate) struct AppSettingsStore {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl AppSettingsStore {
+    /// Create a store using a shared database connection.
+    ///
+    /// The caller is responsible for opening the connection and setting
+    /// pragmas. This constructor runs the migration that creates the
+    /// `app_settings` table if it does not already exist.
+    pub(crate) fn with_conn(conn: Arc<Mutex<Connection>>) -> Result<Self, String> {
+        {
+            let c = conn
+                .lock()
+                .map_err(|e| format!("App settings conn lock error: {e}"))?;
+            c.execute_batch(MIGRATION_0004_GLOBAL_SETTINGS)
+                .map_err(|e| format!("App settings migration error: {e}"))?;
+        }
+        Ok(Self { conn })
+    }
+
+    /// Read a single setting by key.
+    pub(crate) fn get(&self, key: &str) -> Result<Option<String>, String> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| format!("App settings lock error: {e}"))?;
+        conn.query_row(
+            "SELECT value FROM app_settings WHERE key = ?1",
+            params![key],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|e| format!("App settings get error: {e}"))
+    }
+
+    /// Upsert a key-value pair.
+    pub(crate) fn set(&self, key: &str, value: &str) -> Result<(), String> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| format!("App settings lock error: {e}"))?;
+        conn.execute(
+            "INSERT INTO app_settings (key, value, updated_at) VALUES (?1, ?2, datetime('now')) \
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+            params![key, value],
+        )
+        .map_err(|e| format!("App settings set error: {e}"))?;
+        Ok(())
+    }
+
+    /// Return all settings as a key-value map.
+    pub(crate) fn get_all(&self) -> Result<HashMap<String, String>, String> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| format!("App settings lock error: {e}"))?;
+        let mut stmt = conn
+            .prepare("SELECT key, value FROM app_settings")
+            .map_err(|e| format!("App settings prepare error: {e}"))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|e| format!("App settings query error: {e}"))?;
+        let mut map = HashMap::new();
+        for row in rows {
+            let (k, v) = row.map_err(|e| format!("App settings row error: {e}"))?;
+            map.insert(k, v);
+        }
+        Ok(map)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn in_memory_store() -> AppSettingsStore {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        AppSettingsStore::with_conn(Arc::new(Mutex::new(conn))).expect("store")
+    }
+
+    #[test]
+    fn get_missing_key_returns_none() {
+        let store = in_memory_store();
+        assert_eq!(store.get("nonexistent").unwrap(), None);
+    }
+
+    #[test]
+    fn set_and_get_round_trips() {
+        let store = in_memory_store();
+        store.set("active_sprite_id", "cute-dog").unwrap();
+        assert_eq!(
+            store.get("active_sprite_id").unwrap(),
+            Some("cute-dog".to_string())
+        );
+    }
+
+    #[test]
+    fn set_overwrites_existing_value() {
+        let store = in_memory_store();
+        store.set("theme", "light").unwrap();
+        store.set("theme", "dark").unwrap();
+        assert_eq!(store.get("theme").unwrap(), Some("dark".to_string()));
+    }
+
+    #[test]
+    fn get_all_returns_all_entries() {
+        let store = in_memory_store();
+        store.set("a", "1").unwrap();
+        store.set("b", "2").unwrap();
+        let all = store.get_all().unwrap();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all.get("a").unwrap(), "1");
+        assert_eq!(all.get("b").unwrap(), "2");
+    }
+}

--- a/crates/persistence-sqlite/.gitignore
+++ b/crates/persistence-sqlite/.gitignore
@@ -1,0 +1,3 @@
+# Override local git excludes that blanket-ignore *.sql
+# Migration files must be tracked.
+!*.sql

--- a/crates/persistence-sqlite/migrations/0004_global_settings.sql
+++ b/crates/persistence-sqlite/migrations/0004_global_settings.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS app_settings (
+  key        TEXT PRIMARY KEY,
+  value      TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/crates/persistence-sqlite/src/lib.rs
+++ b/crates/persistence-sqlite/src/lib.rs
@@ -3,6 +3,8 @@ pub const MIGRATION_0002_AGENT_SETTINGS: &str =
     include_str!("../migrations/0002_agent_settings.sql");
 pub const MIGRATION_0003_PROVIDER_COMPAT: &str =
     include_str!("../migrations/0003_provider_compat.sql");
+pub const MIGRATION_0004_GLOBAL_SETTINGS: &str =
+    include_str!("../migrations/0004_global_settings.sql");
 
 #[cfg(test)]
 mod tests {
@@ -25,5 +27,11 @@ mod tests {
     #[test]
     fn migration_contains_provider_config_table() {
         assert!(MIGRATION_0003_PROVIDER_COMPAT.contains("CREATE TABLE agent_provider_configs"));
+    }
+
+    #[test]
+    fn migration_contains_global_settings_table() {
+        assert!(MIGRATION_0004_GLOBAL_SETTINGS.contains("CREATE TABLE"));
+        assert!(MIGRATION_0004_GLOBAL_SETTINGS.contains("app_settings"));
     }
 }


### PR DESCRIPTION
## What changed

- Added new `peekoo-app-settings` crate with a key-value SQLite store (`AppSettingsStore`) and `AppSettingsService` facade with sprite validation; 8 unit tests
- Added SQLite migration `0004_global_settings.sql` — `app_settings` key-value table (extensible for future preferences like language/theme)
- Wired `AppSettingsService` into `AgentApplication` in `peekoo-agent-app`, sharing the same SQLite connection
- Added 3 Tauri commands: `app_settings_get`, `app_settings_set`, `app_settings_list_sprites`
- Added **"Settings"** tray menu item (between Show/Hide Pet and Quit) that opens the settings panel
- New `panel-settings` window (420×500) with `SettingsView`, `SettingsPanel`, and `useGlobalSettings` hook
- `SpriteSelector` shows a 2-column grid with live `SpriteAnimation` previews (idle animation, native manifest scale) and active checkmark
- `Sprite.tsx` now loads the active sprite from settings on mount and updates reactively via `sprite:changed` event — default remains `dark-cat`

## Release notes

- feature

## Verification

- [x] Tests pass locally (`peekoo-app-settings`: 8 tests, `peekoo-persistence-sqlite`: 4 tests)
- [x] Clippy clean on changed crates
- [x] TypeScript type check passes
- [x] Vite production build succeeds