### PR TITLE
fix(settings): validate sprite updates and always open settings panel

### DIFF
--- a/apps/desktop-ui/src/hooks/use-panel-windows.ts
+++ b/apps/desktop-ui/src/hooks/use-panel-windows.ts
@@ -126,6 +126,7 @@ export function usePanelWindows() {
     panels,
     pluginPanels,
     installedPlugins,
+    openPanel,
     togglePanel,
   };
 }

--- a/apps/desktop-ui/src/views/SpriteView.test.ts
+++ b/apps/desktop-ui/src/views/SpriteView.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, mock, test } from "bun:test";
+import { openSettingsPanelFromTray } from "./SpriteView";
+
+describe("openSettingsPanelFromTray", () => {
+  test("opens or focuses the settings panel", async () => {
+    const openPanel = mock(async () => {});
+
+    await openSettingsPanelFromTray(openPanel);
+
+    expect(openPanel).toHaveBeenCalledTimes(1);
+    expect(openPanel).toHaveBeenCalledWith("panel-settings");
+  });
+});

--- a/apps/desktop-ui/src/views/SpriteView.tsx
+++ b/apps/desktop-ui/src/views/SpriteView.tsx
@@ -18,16 +18,23 @@ import {
   SPRITE_BUBBLE_EVENT,
   SpriteBubblePayloadSchema,
 } from "@/types/sprite-bubble";
+import type { PanelLabel } from "@/types/window";
 import type { AnimationType, SpriteState } from "@/types/sprite";
 
 // Duration (ms) a reaction-triggered mood override stays active before reverting
 const MOOD_OVERRIDE_DURATION_MS = 3000;
 
+export async function openSettingsPanelFromTray(
+  openPanel: (label: PanelLabel) => Promise<void>,
+) {
+  await openPanel("panel-settings");
+}
+
 export default function SpriteView() {
   const spriteState = useSpriteState();
   const { payload: bubblePayload, visible: bubbleVisible, showBubble, clearBubble } = useSpriteBubble();
   const { items: badgeItems, currentItem: badgeCurrentItem, expanded: badgeExpanded, toggleExpanded: toggleBadgeExpanded, collapse: collapseBadge } = usePeekBadge();
-  const { panels, pluginPanels, installedPlugins, togglePanel } = usePanelWindows();
+  const { panels, pluginPanels, installedPlugins, openPanel, togglePanel } = usePanelWindows();
   const [menuOpen, setMenuOpen] = useState(false);
   const [moodOverride, setMoodOverride] = useState<string | null>(null);
   const [dragAnimation, setDragAnimation] = useState<AnimationType | null>(null);
@@ -115,12 +122,12 @@ export default function SpriteView() {
   // Open settings panel when the tray menu "Settings" item is clicked
   useEffect(() => {
     const unlisten = listen("open-settings", () => {
-      void togglePanel("panel-settings");
+      void openSettingsPanelFromTray(openPanel);
     });
     return () => {
       unlisten.then((fn) => fn());
     };
-  }, [togglePanel]);
+  }, [openPanel]);
 
   // Determine effective sprite state with priority:
   // 1. moodOverride (reactions, reminders) - highest priority

--- a/crates/peekoo-app-settings/src/service.rs
+++ b/crates/peekoo-app-settings/src/service.rs
@@ -85,6 +85,9 @@ impl AppSettingsService {
 
     /// Set a single setting by key.
     pub fn set(&self, key: &str, value: &str) -> Result<(), String> {
+        if key == SETTING_ACTIVE_SPRITE_ID {
+            return self.set_active_sprite_id(value);
+        }
         self.store.set(key, value)
     }
 }
@@ -117,6 +120,17 @@ mod tests {
         let result = svc.set_active_sprite_id("unknown-sprite");
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Unknown sprite"));
+    }
+
+    #[test]
+    fn generic_set_validates_active_sprite_id() {
+        let svc = test_service();
+
+        let result = svc.set(SETTING_ACTIVE_SPRITE_ID, "unknown-sprite");
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown sprite"));
+        assert_eq!(svc.get_active_sprite_id().unwrap(), "dark-cat");
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- route `active_sprite_id` writes through the validated sprite-setting path so invalid sprite ids cannot be persisted through the generic settings API
- make the tray `Settings` action open/focus the settings panel instead of toggling it closed when already open
- add Rust and Bun regression tests covering both behaviors

## Release notes

- [x] Add at least one release-note label: `feature`, `fix`, `docs`, `test`, `chore`, `ci`, or `refactor`
- [ ] Use `skip-changelog` if this PR should be excluded from generated release notes
- fix

## Verification

- [x] Tests pass locally
- [x] `cargo test -p peekoo-app-settings`
- [x] `bun test src/views/SpriteView.test.ts`
- [x] `bun run build`