### PR TITLE
release: version 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5964,7 +5964,7 @@ dependencies = [
 
 [[package]]
 name = "peekoo-desktop-tauri"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "dirs",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT"
-version = "0.1.4"
+version = "0.1.5"
 
 [profile.release]
 lto = true

--- a/apps/desktop-tauri/src-tauri/Cargo.toml
+++ b/apps/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peekoo-desktop-tauri"
-version = "0.1.4"
+version = "0.1.5"
 description = "Peekoo AI Desktop Pet - Tauri Version"
 edition = "2024"
 rust-version = "1.85"

--- a/apps/desktop-tauri/src-tauri/tauri.conf.json
+++ b/apps/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Peekoo",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "identifier": "com.peekoo.desktop",
   "build": {
     "beforeDevCommand": "cd ../desktop-ui && bun run dev",
@@ -37,7 +37,11 @@
     "active": true,
     "targets": "all",
     "createUpdaterArtifacts": true,
-    "icon": ["icons/icon.ico", "icons/icon.icns", "icons/icon.png"]
+    "icon": [
+      "icons/icon.ico",
+      "icons/icon.icns",
+      "icons/icon.png"
+    ]
   },
   "plugins": {
     "updater": {

--- a/apps/desktop-ui/package.json
+++ b/apps/desktop-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "peekoo-desktop",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Peekoo AI Desktop Pet",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump version from 0.1.4 to 0.1.5 across all package manifests
- Updated: Cargo.toml, Cargo.lock, tauri Cargo.toml, tauri.conf.json, package.json

## Changes
- `Cargo.toml`: workspace version 0.1.4 → 0.1.5
- `Cargo.lock`: synced lockfile
- `apps/desktop-tauri/src-tauri/Cargo.toml`: tauri crate version
- `apps/desktop-tauri/src-tauri/tauri.conf.json`: tauri app version
- `apps/desktop-ui/package.json`: frontend package version