### PR TITLE
ci(release): enable Windows long path support to fix pi_agent_rust build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Enable long paths (Windows)
+        if: matrix.platform == 'windows-latest'
+        run: |
+          git config --system core.longpaths true
+          reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
+        shell: pwsh
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 


### PR DESCRIPTION
## What changed

-

## Release notes

- [ ] Add at least one release-note label: `feature`, `fix`, `docs`, `test`, `chore`, `ci`, or `refactor`
- [ ] Use `skip-changelog` if this PR should be excluded from generated release notes

## Verification

- [ ] Tests pass locally
