### PR TITLE
ci: auto-tag on version bump merge to master

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,39 @@
+name: Auto Tag
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - Cargo.toml
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read version from Cargo.toml
+        id: version
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*= *"\(.*\)"/\1/')
+          echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        id: check
+        run: |
+          if git ls-remote --tags origin "${{ steps.version.outputs.version }}" | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## What changed

- Add `auto-tag.yml` workflow that fires on pushes to `master` that touch `Cargo.toml`
- Reads the workspace version from `Cargo.toml`, checks if the tag already exists, and pushes a `v*` tag if not
- The new tag triggers the existing `release.yml` workflow, which builds platform artifacts and creates a draft release

## Release notes

- [x] ci

## Verification

- [ ] Tests pass locally