### PR TITLE
fix(build): bundle rusqlite to fix Windows CI link error for sqlite3.lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4957,6 +4957,7 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ resolver = "2"
 
 [workspace.dependencies]
 pi = { git = "https://github.com/0xRichardH/pi_agent_rust", branch = "main", package = "pi_agent_rust", default-features = false, features = ["image-resize", "clipboard", "sqlite-sessions"] }
+rusqlite = { version = "0.38", features = ["bundled"] }
 asupersync = "=0.2.9"
 
 [workspace.package]

--- a/crates/peekoo-agent-app/Cargo.toml
+++ b/crates/peekoo-agent-app/Cargo.toml
@@ -26,7 +26,7 @@ peekoo-mcp-server = { path = "../peekoo-mcp-server" }
 pi = { workspace = true }
 async-trait = "0.1"
 asupersync = { workspace = true }
-rusqlite = { version = "0.38" }
+rusqlite = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/peekoo-app-settings/Cargo.toml
+++ b/crates/peekoo-app-settings/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2024"
 
 [dependencies]
 peekoo-persistence-sqlite = { path = "../persistence-sqlite" }
-rusqlite = { version = "0.38" }
+rusqlite = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"

--- a/crates/peekoo-plugin-host/Cargo.toml
+++ b/crates/peekoo-plugin-host/Cargo.toml
@@ -30,6 +30,6 @@ toml = "0.8"
 thiserror = "1"
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"
-rusqlite = { version = "0.38" }
+rusqlite = { workspace = true }
 tungstenite = { version = "0.28", features = ["rustls-tls-webpki-roots"] }
 url = "2"

--- a/crates/peekoo-plugin-store/Cargo.toml
+++ b/crates/peekoo-plugin-store/Cargo.toml
@@ -16,4 +16,4 @@ peekoo-notifications = { path = "../peekoo-notifications" }
 peekoo-task-domain = { path = "../peekoo-task-domain" }
 peekoo-task-app = { path = "../peekoo-task-app" }
 peekoo-scheduler = { path = "../peekoo-scheduler" }
-rusqlite = { version = "0.38" }
+rusqlite = { workspace = true }

--- a/crates/peekoo-pomodoro-app/Cargo.toml
+++ b/crates/peekoo-pomodoro-app/Cargo.toml
@@ -8,7 +8,7 @@ chrono = { version = "0.4", features = ["serde"] }
 peekoo-notifications = { path = "../peekoo-notifications" }
 peekoo-pomodoro-domain = { path = "../peekoo-pomodoro-domain" }
 peekoo-scheduler = { path = "../peekoo-scheduler" }
-rusqlite = { version = "0.38" }
+rusqlite = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 tracing = "0.1"

--- a/crates/peekoo-task-app/Cargo.toml
+++ b/crates/peekoo-task-app/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 peekoo-task-domain = { path = "../peekoo-task-domain" }
-rusqlite = { version = "0.38" }
+rusqlite = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"


### PR DESCRIPTION
## What

Enable the `bundled` feature on `rusqlite` across all workspace crates so SQLite is compiled from source rather than requiring a pre-installed `sqlite3.lib` on the host system.

## Why

The Windows CI runner does not have `sqlite3.lib` available, causing a linker error (`LNK1181: cannot open input file 'sqlite3.lib'`) when building the release bundle.

## Changes

- Added `rusqlite = { version = "0.38", features = ["bundled"] }` to `[workspace.dependencies]`
- Updated 6 crates to use `rusqlite = { workspace = true }`:
  - `peekoo-agent-app`
  - `peekoo-app-settings`
  - `peekoo-plugin-host`
  - `peekoo-plugin-store`
  - `peekoo-pomodoro-app`
  - `peekoo-task-app`