### PR TITLE
chore(release): bump version to 0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5974,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "peekoo-desktop-tauri"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "dirs",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ asupersync = "=0.2.9"
 [workspace.package]
 edition = "2024"
 license = "MIT"
-version = "0.1.6"
+version = "0.1.7"
 
 [profile.release]
 lto = true

--- a/apps/desktop-tauri/src-tauri/Cargo.toml
+++ b/apps/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peekoo-desktop-tauri"
-version = "0.1.6"
+version = "0.1.7"
 description = "Peekoo AI Desktop Pet - Tauri Version"
 edition = "2024"
 rust-version = "1.85"

--- a/apps/desktop-tauri/src-tauri/tauri.conf.json
+++ b/apps/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Peekoo",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "identifier": "com.peekoo.desktop",
   "build": {
     "beforeDevCommand": "cd ../desktop-ui && bun run dev",

--- a/apps/desktop-ui/package.json
+++ b/apps/desktop-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "peekoo-desktop",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Peekoo AI Desktop Pet",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What changed

- Bump the repo, Tauri app, and desktop UI versions from 0.1.6 to 0.1.7.
- Refresh `Cargo.lock` so the workspace release metadata stays in sync.

## Release notes

- [x] Add at least one release-note label: `feature`, `fix`, `docs`, `test`, `chore`, `ci`, or `refactor`
- [x] Use `skip-changelog` if this PR should be excluded from generated release notes

## Verification

- [x] Tests pass locally