### PR TITLE
fix(release): trigger releases from auto tag workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_run:
+    workflows: ["Auto Tag"]
+    types: [completed]
   release:
     types: [published]
   workflow_dispatch:
@@ -21,13 +21,64 @@ permissions:
   contents: write
 
 jobs:
+  prepare-release:
+    if: >-
+      (github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'master') ||
+      (github.event_name == 'workflow_dispatch' && !inputs.publish_aur && !inputs.finalize_release_tag)
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.resolve.outputs.tag_name }}
+      tag_version: ${{ steps.resolve.outputs.tag_version }}
+      target_sha: ${{ steps.resolve.outputs.target_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Resolve release tag
+        id: resolve
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*= *"\(.*\)"/\1/')
+          TAG_NAME="v${VERSION}"
+
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            TARGET_SHA="${{ github.event.workflow_run.head_sha }}"
+            git fetch --force --tags origin
+            TAG_SHA=$(git rev-list -n 1 "$TAG_NAME" 2>/dev/null || true)
+
+            if [ -z "$TAG_SHA" ]; then
+              echo "Expected tag $TAG_NAME does not exist" >&2
+              exit 1
+            fi
+
+            if [ "$TAG_SHA" != "$TARGET_SHA" ]; then
+              echo "Tag $TAG_NAME points to $TAG_SHA, expected $TARGET_SHA" >&2
+              exit 1
+            fi
+          else
+            TARGET_SHA=$(git rev-parse HEAD)
+          fi
+
+          {
+            echo "tag_name=$TAG_NAME"
+            echo "tag_version=$VERSION"
+            echo "target_sha=$TARGET_SHA"
+          } >> "$GITHUB_OUTPUT"
+
   release-notes:
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.publish_aur && !inputs.finalize_release_tag)
+    needs: prepare-release
+    if: needs.prepare-release.result == 'success'
     runs-on: ubuntu-latest
     outputs:
       release_body: ${{ steps.notes.outputs.release_body }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.prepare-release.outputs.target_sha }}
 
       - name: Generate release notes
         id: notes
@@ -37,8 +88,8 @@ jobs:
           gh api \
             "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
             --method POST \
-            --field tag_name="${GITHUB_REF_NAME}" \
-            --field target_commitish="${GITHUB_SHA}" \
+            --field tag_name="${{ needs.prepare-release.outputs.tag_name }}" \
+            --field target_commitish="${{ needs.prepare-release.outputs.target_sha }}" \
             --jq .body > release-notes.md
           printf '\n---\n\n> macOS users: The macOS DMG is not yet notarized with Apple. After installing, open Terminal and run `xattr -cr /Applications/Peekoo.app` to allow the app to open. See the [macOS install guide](https://github.com/feed-mob/peekoo-ai/blob/master/docs/install-macos.md) for details.\n' >> release-notes.md
           {
@@ -48,8 +99,8 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   publish-tauri:
-    needs: release-notes
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.publish_aur && !inputs.finalize_release_tag)
+    needs: [prepare-release, release-notes]
+    if: needs.prepare-release.result == 'success' && needs.release-notes.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -67,6 +118,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ needs.prepare-release.outputs.target_sha }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -102,8 +154,8 @@ jobs:
           TAURI_CONFIG: ${{ matrix.platform == 'macos-14' && '{"app":{"macOSPrivateApi":true}}' || '{"app":{"macOSPrivateApi":false}}' }}
         with:
           projectPath: apps/desktop-tauri
-          tagName: v__VERSION__
-          releaseName: Peekoo v__VERSION__
+          tagName: ${{ needs.prepare-release.outputs.tag_name }}
+          releaseName: Peekoo ${{ needs.prepare-release.outputs.tag_name }}
           releaseBody: ${{ needs.release-notes.outputs.release_body }}
           releaseDraft: true
           prerelease: false

--- a/ai/memories/changelogs/202603271501-fix-release-workflow-trigger.md
+++ b/ai/memories/changelogs/202603271501-fix-release-workflow-trigger.md
@@ -1,0 +1,16 @@
+## 2026-03-27 15:01: fix: release workflow trigger after auto tag
+
+**What changed:**
+- Switched `.github/workflows/release.yml` from a tag-push trigger to a `workflow_run` trigger that starts after `Auto Tag` completes successfully
+- Added a `prepare-release` job that resolves the version tag from `Cargo.toml`, verifies that the matching tag exists, and confirms that it points at the same commit the auto-tag run processed
+- Updated the release jobs to build and generate notes from the resolved commit SHA and tag name instead of relying on the event ref
+- Updated `docs/release.md` to describe the PR -> merge -> Auto Tag -> Release flow and the remaining manual finalize step
+
+**Why:**
+- Tags created by `Auto Tag` use the default GitHub Actions token, which does not trigger downstream `push` workflows
+- Triggering `Release` from `workflow_run` preserves the automated release flow without requiring a PAT or GitHub App token
+- Resolving the release tag in a dedicated job keeps the release build tied to the exact commit that `Auto Tag` tagged
+
+**Files affected:**
+- `.github/workflows/release.yml`
+- `docs/release.md`

--- a/docs/release.md
+++ b/docs/release.md
@@ -23,7 +23,8 @@
 
 ## Workflows
 
-- `Release`: builds installers on tag push or manual dispatch, creates updater artifacts, drafts a GitHub Release, can publish a draft release as latest, and publishes to AUR when the release is published.
+- `Auto Tag`: watches `master` for version bumps in `Cargo.toml`, then creates the matching `v0.x.y` tag.
+- `Release`: runs after `Auto Tag` succeeds or from manual dispatch, builds installers, creates updater artifacts, drafts a GitHub Release, can publish a draft release as latest, and publishes to AUR when the release is published.
 - `PR Release Label`: fails non-draft PRs that do not have a release-note label.
 - `CI`: validates the workspace, release tooling tests, and the desktop UI build.
 
@@ -53,8 +54,8 @@ Use `.github/pull_request_template.md` as the default checklist when opening PRs
 
 ## Standard tagged release
 
-1. Merge the changes you want released into `master`.
-2. Start from a clean working copy.
+1. Start from a clean working copy.
+2. Create a branch for the release bump.
 3. Run:
 
    ```bash
@@ -70,25 +71,29 @@ Use `.github/pull_request_template.md` as the default checklist when opening PRs
    cd apps/desktop-ui && bun run build
    ```
 
-5. Create and push the release commit and tag:
+5. Create and push the release commit:
 
    ```bash
-   just release 0.x.y
+   git add Cargo.toml Cargo.lock apps/desktop-tauri/src-tauri/Cargo.toml apps/desktop-tauri/src-tauri/tauri.conf.json apps/desktop-ui/package.json
+   git commit -S -m "chore(release): bump version to 0.x.y"
+   git push origin <branch>
    ```
 
-6. GitHub Actions runs the `Release` workflow automatically from the `v0.x.y` tag.
-7. The workflow:
-   - builds Windows installers (`nsis`, `msi`)
-   - builds a macOS ARM64 `dmg` plus updater archives
-   - builds Linux `AppImage` and `deb`
-   - signs updater artifacts with the Tauri private key
-   - asks GitHub to generate release notes
-   - creates a draft GitHub Release
-8. Open the draft release in GitHub.
-9. Verify the uploaded files and the generated notes.
-10. Open `Actions` -> `Release` -> `Run workflow`.
-11. Set `finalize_release_tag` to `v0.x.y` and run the workflow.
-12. The workflow publishes the draft release, marks it as GitHub's latest release, and triggers the `publish-aur` job automatically.
+6. Open a PR for the release bump and merge it into `master`.
+7. `Auto Tag` creates `v0.x.y` from the merged `master` commit.
+8. GitHub Actions runs the `Release` workflow automatically after `Auto Tag` finishes.
+9. The workflow:
+    - builds Windows installers (`nsis`, `msi`)
+    - builds a macOS ARM64 `dmg` plus updater archives
+    - builds Linux `AppImage` and `deb`
+    - signs updater artifacts with the Tauri private key
+    - asks GitHub to generate release notes
+    - creates a draft GitHub Release
+10. Open the draft release in GitHub.
+11. Verify the uploaded files and the generated notes.
+12. Open `Actions` -> `Release` -> `Run workflow`.
+13. Set `finalize_release_tag` to `v0.x.y` and run the workflow.
+14. The workflow publishes the draft release, marks it as GitHub's latest release, and triggers the `publish-aur` job automatically.
 
 ## Manual workflow dispatch
 


### PR DESCRIPTION
## What changed

- Switch the release workflow from tag-push triggers to `workflow_run` so it starts after `Auto Tag` completes on `master`.
- Add a prepare step that resolves the version tag from `Cargo.toml`, verifies the tag exists, and pins release jobs to the tagged commit SHA.
- Update the release docs and changelog to describe the PR -> merge -> Auto Tag -> Release flow.

## Release notes

- [x] Add at least one release-note label: `feature`, `fix`, `docs`, `test`, `chore`, `ci`, or `refactor`
- [ ] Use `skip-changelog` if this PR should be excluded from generated release notes

## Verification

- [x] `python -m unittest tests.test_release`
- [x] Validated `.github/workflows/release.yml` trigger configuration with a Python YAML parse