### PR TITLE
feat(agent): parse task input via ACP with fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ plugins/*/Cargo.lock
 .DS_Store
 .idea/
 .vscode/
+.opencode/
 .opencode/plans/
 .codex
 .cursor

--- a/ai/memories/changelogs/202604111730-feat-acp-task-creation-parser-and-shared-client.md
+++ b/ai/memories/changelogs/202604111730-feat-acp-task-creation-parser-and-shared-client.md
@@ -1,0 +1,24 @@
+## 2026-04-11 17:30: feat: ACP task creation parser and shared client
+
+**What changed:**
+- Added ACP prompt-based task creation parsing via `peekoo-agent-acp` using a new `task_creation_parse` payload mode.
+- Updated task creation in `peekoo-agent-app` to parse with ACP first, then fallback to the existing regex parser.
+- Added parser output normalization and validation (priority/assignee guards, timestamp parsing, string trimming, label normalization).
+- Added ACP prompt timeout for task parsing to avoid blocking on slow/failed runtimes.
+- Extracted duplicated ACP subprocess/session/prompt flow into a shared helper module and reused it from both scheduler task execution and task-creation parsing.
+- Added tests for ACP prompt context detection and parser normalization helpers.
+
+**Why:**
+- Improve natural-language task input quality by leveraging agent parsing while keeping reliability through permanent fallback.
+- Reduce maintenance risk by centralizing ACP client orchestration logic.
+- Keep UI and Tauri command contracts unchanged while evolving backend parsing behavior.
+
+**Files affected:**
+- `ai/plans/2026-04-11-task-creation-acp-parser.md`
+- `crates/peekoo-agent-acp/src/context.rs`
+- `crates/peekoo-agent-acp/src/agent.rs`
+- `crates/peekoo-agent-app/src/acp_client.rs`
+- `crates/peekoo-agent-app/src/agent_scheduler.rs`
+- `crates/peekoo-agent-app/src/application.rs`
+- `crates/peekoo-agent-app/src/lib.rs`
+- `crates/peekoo-agent-app/Cargo.toml`

--- a/ai/plans/2026-04-11-task-creation-acp-parser.md
+++ b/ai/plans/2026-04-11-task-creation-acp-parser.md
@@ -1,0 +1,65 @@
+# Plan: ACP Prompt-Based Task Creation Parsing
+
+## Overview
+
+Use `peekoo-agent-acp` to parse task quick-input text into structured fields via ACP `prompt`, while keeping the existing regex parser as a permanent fallback.
+
+## Goals
+
+- [x] Add ACP parse payload support in `peekoo-agent-acp`
+- [ ] Parse task creation text via ACP in `peekoo-agent-app`
+- [ ] Preserve existing fallback behavior using local regex parser
+- [ ] Keep frontend and Tauri command surface unchanged
+- [ ] Add tests for parse-context detection and fallback behavior
+
+## Design
+
+### Approach
+
+- Extend ACP prompt payload detection with a dedicated `task_creation_parse` request type.
+- Reuse ACP `prompt` to run parsing through the same sidecar binary used for task execution.
+- Keep parsing robust by validating ACP output and falling back to `task_parser::parse_task_text` on any failure.
+
+### Components
+
+- `peekoo-agent-acp context`: add `TaskCreationContext` with `request_type`, `raw_text`, `locale`, `timezone`
+- `peekoo-agent-acp agent`: route prompt payloads to task execution or task creation parse mode
+- `peekoo-agent-app application`: call ACP parser in `create_task_from_text` and fallback to regex parser
+
+## Implementation Steps
+
+1. **ACP Parse Context**
+   - Add `TaskCreationContext` in `crates/peekoo-agent-acp/src/context.rs`
+   - Add parser prompt builder that enforces JSON-only output
+
+2. **ACP Prompt Routing**
+   - Update prompt context extraction in `crates/peekoo-agent-acp/src/agent.rs`
+   - Detect `task_creation_parse` payloads and run parse prompt mode
+   - Keep existing task execution flow unchanged
+
+3. **App-Layer ACP Parse Integration**
+   - Update `AgentApplication::create_task_from_text` to try ACP parse first
+   - Deserialize and validate returned JSON
+   - Fallback to `task_parser::parse_task_text` when ACP parse fails
+
+4. **Validation + Fallback Safety**
+   - Normalize enum fields (`priority`, `assignee`)
+   - Guard against invalid JSON/no content/transport failures
+   - Preserve existing create-task behavior and defaults
+
+5. **Testing**
+   - Add/extend unit tests for ACP context detection and parse payload mode
+   - Ensure fallback behavior remains intact
+
+## Files to Modify
+
+- `ai/plans/2026-04-11-task-creation-acp-parser.md`
+- `crates/peekoo-agent-acp/src/context.rs`
+- `crates/peekoo-agent-acp/src/agent.rs`
+- `crates/peekoo-agent-app/src/application.rs`
+
+## Testing Strategy
+
+- `cargo test -p peekoo-agent-acp`
+- `cargo test -p peekoo-agent-app`
+- `just check`

--- a/crates/peekoo-agent-acp/src/agent.rs
+++ b/crates/peekoo-agent-acp/src/agent.rs
@@ -20,7 +20,7 @@ use peekoo_agent::{
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
-use crate::context::TaskContext;
+use crate::context::{TaskContext, TaskCreationContext};
 // TODO: Re-enable after MCP bridge migration
 // use crate::mcp_tools::{TaskScopedTool, summarize_agent_event};
 
@@ -48,31 +48,41 @@ impl PeekooAgent {
     }
 }
 
-fn extract_task_context(prompt: &[acp::ContentBlock]) -> TaskContext {
-    prompt
-        .iter()
-        .find_map(|block| {
-            if let acp::ContentBlock::Text(text) = block {
-                serde_json::from_str::<TaskContext>(&text.text).ok()
-            } else {
-                None
-            }
-        })
-        .unwrap_or_else(|| {
-            tracing::warn!("No task context provided, using default");
-            TaskContext {
-                task_id: "unknown".to_string(),
-                title: "Untitled Task".to_string(),
-                description: None,
-                status: "todo".to_string(),
-                priority: "medium".to_string(),
-                labels: vec![],
-                scheduled_start_at: None,
-                scheduled_end_at: None,
-                estimated_duration_min: None,
-                comments: vec![],
-            }
-        })
+enum PromptContext {
+    TaskExecution(TaskContext),
+    TaskCreation(TaskCreationContext),
+}
+
+fn extract_prompt_context(prompt: &[acp::ContentBlock]) -> PromptContext {
+    for block in prompt {
+        let acp::ContentBlock::Text(text) = block else {
+            continue;
+        };
+
+        if let Ok(context) = serde_json::from_str::<TaskCreationContext>(&text.text)
+            && context.request_type == "task_creation_parse"
+        {
+            return PromptContext::TaskCreation(context);
+        }
+
+        if let Ok(context) = serde_json::from_str::<TaskContext>(&text.text) {
+            return PromptContext::TaskExecution(context);
+        }
+    }
+
+    tracing::warn!("No task context provided, using default");
+    PromptContext::TaskExecution(TaskContext {
+        task_id: "unknown".to_string(),
+        title: "Untitled Task".to_string(),
+        description: None,
+        status: "todo".to_string(),
+        priority: "medium".to_string(),
+        labels: vec![],
+        scheduled_start_at: None,
+        scheduled_end_at: None,
+        estimated_duration_min: None,
+        comments: vec![],
+    })
 }
 
 #[async_trait(?Send)]
@@ -142,7 +152,7 @@ impl acp::Agent for PeekooAgent {
             arguments.session_id
         );
 
-        let task_context = extract_task_context(&arguments.prompt);
+        let prompt_context = extract_prompt_context(&arguments.prompt);
 
         let session_context = self
             .sessions
@@ -150,56 +160,70 @@ impl acp::Agent for PeekooAgent {
             .get(&arguments.session_id.to_string())
             .cloned();
 
-        let task_prompt = task_context.to_prompt();
-
-        let (tx, rx) = oneshot::channel();
-        self.session_update_tx
-            .send((
-                SessionNotification::new(
-                    arguments.session_id.clone(),
-                    SessionUpdate::AgentMessageChunk(ContentChunk::new(
-                        format!(
-                            "Processing task: {}\n\nPreparing agent session...\n\n",
-                            task_context.title
-                        )
-                        .into(),
-                    )),
+        let (task_prompt, task_id, startup_text, preparing_text, emit_progress_updates) =
+            match &prompt_context {
+                PromptContext::TaskExecution(task_context) => (
+                    task_context.to_prompt(),
+                    task_context.task_id.clone(),
+                    format!(
+                        "Task received: {}\n\nMCP servers forwarded: {}\n\nRunning agent...",
+                        task_context.task_id,
+                        session_context
+                            .as_ref()
+                            .map(|session| session.mcp_servers.len())
+                            .unwrap_or_default()
+                    ),
+                    format!(
+                        "Processing task: {}\n\nPreparing agent session...\n\n",
+                        task_context.title
+                    ),
+                    true,
                 ),
-                tx,
-            ))
-            .map_err(|_| anyhow::anyhow!("failed to send session update"))?;
-        rx.await
-            .map_err(|_| anyhow::anyhow!("session update failed"))?;
+                PromptContext::TaskCreation(parse_context) => (
+                    parse_context.to_prompt(),
+                    "task-creation-parse".to_string(),
+                    String::new(),
+                    String::new(),
+                    false,
+                ),
+            };
 
-        let mut agent = build_agent_service(&task_context.task_id, session_context.as_ref())
+        if emit_progress_updates {
+            let (tx, rx) = oneshot::channel();
+            self.session_update_tx
+                .send((
+                    SessionNotification::new(
+                        arguments.session_id.clone(),
+                        SessionUpdate::AgentMessageChunk(ContentChunk::new(preparing_text.into())),
+                    ),
+                    tx,
+                ))
+                .map_err(|_| anyhow::anyhow!("failed to send session update"))?;
+            rx.await
+                .map_err(|_| anyhow::anyhow!("session update failed"))?;
+        }
+
+        let mut agent = build_agent_service(&task_id, session_context.as_ref())
             .await
             .map_err(|error| {
                 tracing::error!("Failed to create task agent: {}", error);
                 acp::Error::internal_error()
             })?;
 
-        let mcp_server_count = session_context
-            .as_ref()
-            .map(|session| session.mcp_servers.len())
-            .unwrap_or_default();
-
-        let startup_text = format!(
-            "Task received: {}\n\nMCP servers forwarded: {}\n\nRunning agent...",
-            task_context.task_id, mcp_server_count
-        );
-
-        let (tx, rx) = oneshot::channel();
-        self.session_update_tx
-            .send((
-                SessionNotification::new(
-                    arguments.session_id.clone(),
-                    SessionUpdate::AgentMessageChunk(ContentChunk::new(startup_text.into())),
-                ),
-                tx,
-            ))
-            .map_err(|_| anyhow::anyhow!("failed to send session update"))?;
-        rx.await
-            .map_err(|_| anyhow::anyhow!("session update failed"))?;
+        if emit_progress_updates {
+            let (tx, rx) = oneshot::channel();
+            self.session_update_tx
+                .send((
+                    SessionNotification::new(
+                        arguments.session_id.clone(),
+                        SessionUpdate::AgentMessageChunk(ContentChunk::new(startup_text.into())),
+                    ),
+                    tx,
+                ))
+                .map_err(|_| anyhow::anyhow!("failed to send session update"))?;
+            rx.await
+                .map_err(|_| anyhow::anyhow!("session update failed"))?;
+        }
 
         let final_text = agent
             .prompt(&task_prompt, move |event: AgentEvent| {
@@ -427,9 +451,9 @@ mod tests {
 
     use super::{
         SessionContext, TaskSessionStorage, build_agent_service_config, build_task_session_storage,
-        extract_task_context,
+        extract_prompt_context,
     };
-    use crate::context::Comment;
+    use crate::context::{Comment, TaskCreationContext};
 
     #[test]
     fn reuses_legacy_session_file_when_it_exists() {
@@ -527,7 +551,10 @@ mod tests {
             agent_client_protocol::ContentBlock::Text(TextContent::new(task_json)),
         ];
 
-        let task_context = extract_task_context(&prompt);
+        let prompt_context = extract_prompt_context(&prompt);
+        let super::PromptContext::TaskExecution(task_context) = prompt_context else {
+            panic!("expected task execution context");
+        };
 
         assert_eq!(task_context.task_id, "task-123");
         assert_eq!(task_context.title, "Finish task");
@@ -542,5 +569,28 @@ mod tests {
             }
             .text
         );
+    }
+
+    #[test]
+    fn extract_prompt_context_detects_task_creation_payload() {
+        let parse_json = serde_json::to_string(&TaskCreationContext {
+            request_type: "task_creation_parse".into(),
+            raw_text: "call mom tomorrow at 3pm".into(),
+            locale: Some("en-US".into()),
+            timezone: Some("UTC".into()),
+        })
+        .expect("serialize parse context");
+
+        let prompt = vec![agent_client_protocol::ContentBlock::Text(TextContent::new(
+            parse_json,
+        ))];
+        let prompt_context = extract_prompt_context(&prompt);
+
+        let super::PromptContext::TaskCreation(context) = prompt_context else {
+            panic!("expected task creation context");
+        };
+
+        assert_eq!(context.request_type, "task_creation_parse");
+        assert_eq!(context.raw_text, "call mom tomorrow at 3pm");
     }
 }

--- a/crates/peekoo-agent-acp/src/context.rs
+++ b/crates/peekoo-agent-acp/src/context.rs
@@ -15,6 +15,14 @@ pub struct TaskContext {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskCreationContext {
+    pub request_type: String,
+    pub raw_text: String,
+    pub locale: Option<String>,
+    pub timezone: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Comment {
     pub id: String,
     pub author: String,
@@ -89,6 +97,42 @@ impl TaskContext {
         prompt.push_str("Example completion sequence: first call `task_comment` with the result, then call `update_task_status` with `done`.\n\n");
 
         prompt
+    }
+}
+
+impl TaskCreationContext {
+    pub fn to_prompt(&self) -> String {
+        format!(
+            r#"You are a task parsing assistant. Convert the user input into a single JSON object only.
+
+Return ONLY valid JSON with this exact shape (no markdown, no explanation):
+{{
+  "title": string,
+  "priority": "high" | "medium" | "low" | null,
+  "assignee": "user" | "agent" | null,
+  "labels": string[],
+  "description": string | null,
+  "scheduled_start_at": string | null,
+  "scheduled_end_at": string | null,
+  "estimated_duration_min": number | null,
+  "recurrence_rule": string | null,
+  "recurrence_time_of_day": string | null
+}}
+
+Rules:
+- Preserve user intent in title.
+- If uncertain, use null instead of guessing.
+- Use RFC3339 timestamps when extracting dates/times.
+- Keep labels short and lowercase.
+- Do not add any keys.
+
+Locale: {}
+Timezone: {}
+User input: {}"#,
+            self.locale.as_deref().unwrap_or("en"),
+            self.timezone.as_deref().unwrap_or("UTC"),
+            self.raw_text
+        )
     }
 }
 

--- a/crates/peekoo-agent-app/Cargo.toml
+++ b/crates/peekoo-agent-app/Cargo.toml
@@ -34,7 +34,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
 tracing = "0.1"
-tokio = { version = "1.50.0", features = ["sync", "process", "io-util", "rt-multi-thread", "net"] }
+tokio = { version = "1.50.0", features = ["sync", "process", "io-util", "rt-multi-thread", "net", "time"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/peekoo-agent-app/src/acp_client.rs
+++ b/crates/peekoo-agent-app/src/acp_client.rs
@@ -1,0 +1,292 @@
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use agent_client_protocol::{
+    Agent as _, Client, ClientSideConnection, ContentBlock, InitializeRequest, McpServer,
+    McpServerHttp, NewSessionRequest, PromptRequest, ProtocolVersion, SessionNotification,
+    SessionUpdate, StopReason,
+};
+use tokio::process::Command;
+use tokio::task::LocalSet;
+use tokio::time::{Duration, timeout};
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+pub(crate) struct AcpPromptResult {
+    pub text: String,
+    pub stop_reason: StopReason,
+}
+
+#[derive(Clone)]
+struct PromptClient {
+    context: String,
+    output: Arc<Mutex<String>>,
+}
+
+#[async_trait::async_trait(?Send)]
+impl Client for PromptClient {
+    async fn request_permission(
+        &self,
+        args: agent_client_protocol::RequestPermissionRequest,
+    ) -> Result<agent_client_protocol::RequestPermissionResponse, agent_client_protocol::Error>
+    {
+        if let Some(option) = args.options.iter().find(|option| {
+            matches!(
+                option.kind,
+                agent_client_protocol::PermissionOptionKind::AllowOnce
+                    | agent_client_protocol::PermissionOptionKind::AllowAlways
+            )
+        }) {
+            Ok(agent_client_protocol::RequestPermissionResponse::new(
+                agent_client_protocol::RequestPermissionOutcome::Selected(
+                    agent_client_protocol::SelectedPermissionOutcome::new(option.option_id.clone()),
+                ),
+            ))
+        } else {
+            Ok(agent_client_protocol::RequestPermissionResponse::new(
+                agent_client_protocol::RequestPermissionOutcome::Cancelled,
+            ))
+        }
+    }
+
+    async fn session_notification(
+        &self,
+        args: SessionNotification,
+    ) -> Result<(), agent_client_protocol::Error> {
+        match args.update {
+            SessionUpdate::AgentMessageChunk(chunk) => {
+                if let ContentBlock::Text(text) = chunk.content {
+                    if let Ok(mut guard) = self.output.lock() {
+                        guard.push_str(&text.text);
+                    }
+                    tracing::debug!(
+                        "ACP [{}] chunk: {}",
+                        self.context,
+                        text.text.chars().take(200).collect::<String>()
+                    );
+                }
+            }
+            SessionUpdate::ToolCall(tool_call) => {
+                tracing::info!(
+                    "ACP [{}] tool call: {} ({:?})",
+                    self.context,
+                    tool_call.title,
+                    tool_call.kind
+                );
+            }
+            SessionUpdate::ToolCallUpdate(update) => {
+                tracing::info!("ACP [{}] tool update: {:?}", self.context, update.fields);
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn resolve_acp_command_path(
+    bundled_acp_path: Option<PathBuf>,
+    current_exe: Option<PathBuf>,
+) -> PathBuf {
+    if let Some(path) = bundled_acp_path.filter(|path| path.exists() && path.is_file()) {
+        return path;
+    }
+
+    let bin_name = if cfg!(windows) {
+        "peekoo-agent-acp.exe"
+    } else {
+        "peekoo-agent-acp"
+    };
+
+    current_exe
+        .and_then(|exe| exe.parent().map(|p| p.join(bin_name)))
+        .filter(|p| p.exists())
+        .unwrap_or_else(|| PathBuf::from(bin_name))
+}
+
+pub(crate) fn build_session_mcp_servers(
+    mcp_address: Option<std::net::SocketAddr>,
+) -> Vec<McpServer> {
+    mcp_address
+        .map(|addr| {
+            let base_url = peekoo_mcp_server::mcp_url_for(addr);
+            let plugins_url = format!("{}/plugins", base_url);
+            vec![
+                McpServer::Http(McpServerHttp::new("peekoo-native-tools", base_url)),
+                McpServer::Http(McpServerHttp::new("peekoo-plugin-tools", plugins_url)),
+            ]
+        })
+        .unwrap_or_default()
+}
+
+pub(crate) async fn run_prompt_and_collect(
+    context: &str,
+    content_blocks: Vec<ContentBlock>,
+    launch_env: Vec<(String, String)>,
+    mcp_address: Option<std::net::SocketAddr>,
+    bundled_acp_path: Option<PathBuf>,
+    prompt_timeout: Option<Duration>,
+) -> Result<AcpPromptResult, String> {
+    let command_path = resolve_acp_command_path(bundled_acp_path, std::env::current_exe().ok());
+    let output = Arc::new(Mutex::new(String::new()));
+
+    let mut cmd = Command::new(&command_path);
+    if let Some(addr) = mcp_address {
+        cmd.env("PEEKOO_MCP_PORT", addr.port().to_string())
+            .env("PEEKOO_MCP_HOST", addr.ip().to_string());
+    }
+    for (key, value) in launch_env {
+        cmd.env(key, value);
+    }
+
+    let mut child = cmd
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit())
+        .spawn()
+        .map_err(|e| format!("Spawn ACP process error: {e}"))?;
+
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| "ACP stdin unavailable".to_string())?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "ACP stdout unavailable".to_string())?;
+
+    let local_set = LocalSet::new();
+    let output_clone = Arc::clone(&output);
+    let context_label = context.to_string();
+
+    let prompt_result = local_set
+        .run_until(async move {
+            let (conn, handle_io) = ClientSideConnection::new(
+                PromptClient {
+                    context: context_label.clone(),
+                    output: output_clone,
+                },
+                stdin.compat_write(),
+                stdout.compat(),
+                |fut| {
+                    tokio::task::spawn_local(fut);
+                },
+            );
+
+            tokio::task::spawn_local(async move {
+                if let Err(err) = handle_io.await {
+                    tracing::warn!("ACP [{}] I/O error: {}", context_label, err);
+                }
+            });
+
+            conn.initialize(InitializeRequest::new(ProtocolVersion::V1))
+                .await
+                .map_err(|e| format!("ACP initialize error: {e}"))?;
+
+            let session = conn
+                .new_session(
+                    NewSessionRequest::new(std::env::current_dir().unwrap_or_default())
+                        .mcp_servers(build_session_mcp_servers(mcp_address)),
+                )
+                .await
+                .map_err(|e| format!("ACP new_session error: {e}"))?;
+
+            let response = if let Some(limit) = prompt_timeout {
+                timeout(
+                    limit,
+                    conn.prompt(PromptRequest::new(session.session_id, content_blocks)),
+                )
+                .await
+                .map_err(|_| format!("ACP prompt timed out after {}s", limit.as_secs()))?
+                .map_err(|e| format!("ACP prompt error: {e}"))?
+            } else {
+                conn.prompt(PromptRequest::new(session.session_id, content_blocks))
+                    .await
+                    .map_err(|e| format!("ACP prompt error: {e}"))?
+            };
+
+            Ok::<_, String>(response.stop_reason)
+        })
+        .await;
+
+    let _ = child.kill().await;
+
+    let stop_reason = prompt_result?;
+    let text = output
+        .lock()
+        .map_err(|e| format!("ACP output lock error: {e}"))?
+        .clone();
+
+    Ok(AcpPromptResult { text, stop_reason })
+}
+
+pub(crate) fn run_prompt_and_collect_blocking(
+    context: &str,
+    content_blocks: Vec<ContentBlock>,
+    launch_env: Vec<(String, String)>,
+    mcp_address: Option<std::net::SocketAddr>,
+    bundled_acp_path: Option<PathBuf>,
+    prompt_timeout: Option<Duration>,
+) -> Result<AcpPromptResult, String> {
+    let context = context.to_string();
+
+    std::thread::spawn(move || -> Result<AcpPromptResult, String> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| format!("Create tokio runtime error: {e}"))?;
+
+        runtime.block_on(run_prompt_and_collect(
+            &context,
+            content_blocks,
+            launch_env,
+            mcp_address,
+            bundled_acp_path,
+            prompt_timeout,
+        ))
+    })
+    .join()
+    .map_err(|_| "ACP client thread panicked".to_string())?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_session_mcp_servers, resolve_acp_command_path};
+
+    #[test]
+    fn builds_http_mcp_server_for_session() {
+        let servers = build_session_mcp_servers(Some(([127, 0, 0, 1], 49152).into()));
+        let serialized = serde_json::to_value(&servers).expect("serialize mcp servers");
+        assert_eq!(serialized[0]["type"], "http");
+        assert_eq!(serialized[0]["name"], "peekoo-native-tools");
+        assert_eq!(serialized[0]["url"], "http://127.0.0.1:49152/mcp");
+    }
+
+    #[test]
+    fn resolve_acp_command_path_prefers_explicit_bundled_path() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bundled = temp.path().join("peekoo-agent-acp");
+        std::fs::write(&bundled, "").expect("create bundled binary");
+
+        let resolved =
+            resolve_acp_command_path(Some(bundled.clone()), Some(temp.path().join("desktop")));
+
+        assert_eq!(resolved, bundled);
+    }
+
+    #[test]
+    fn resolve_acp_command_path_uses_sibling_binary_when_present() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let exe_dir = temp.path().join("bin");
+        std::fs::create_dir_all(&exe_dir).expect("create bin dir");
+        let current_exe = exe_dir.join("peekoo-desktop");
+        let sibling = exe_dir.join(if cfg!(windows) {
+            "peekoo-agent-acp.exe"
+        } else {
+            "peekoo-agent-acp"
+        });
+        std::fs::write(&sibling, "").expect("create sibling binary");
+
+        let resolved = resolve_acp_command_path(None, Some(current_exe));
+
+        assert_eq!(resolved, sibling);
+    }
+}

--- a/crates/peekoo-agent-app/src/agent_scheduler.rs
+++ b/crates/peekoo-agent-app/src/agent_scheduler.rs
@@ -1,14 +1,8 @@
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use agent_client_protocol::{
-    Client, ClientSideConnection, ContentBlock, InitializeRequest, McpServer, McpServerHttp,
-    NewSessionRequest, PromptRequest, ProtocolVersion, TextContent,
-};
+use agent_client_protocol::{ContentBlock, TextContent};
 use peekoo_scheduler::Scheduler;
-use tokio::process::Command;
-use tokio::task::LocalSet;
-use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use peekoo_task_app::SqliteTaskService;
 
@@ -166,26 +160,6 @@ impl AgentScheduler {
     }
 }
 
-fn resolve_acp_command_path(
-    bundled_acp_path: Option<std::path::PathBuf>,
-    current_exe: Option<std::path::PathBuf>,
-) -> std::path::PathBuf {
-    if let Some(path) = bundled_acp_path.filter(|path| path.exists() && path.is_file()) {
-        return path;
-    }
-
-    let bin_name = if cfg!(windows) {
-        "peekoo-agent-acp.exe"
-    } else {
-        "peekoo-agent-acp"
-    };
-
-    current_exe
-        .and_then(|exe| exe.parent().map(|p| p.join(bin_name)))
-        .filter(|p| p.exists())
-        .unwrap_or_else(|| std::path::PathBuf::from(bin_name))
-}
-
 async fn check_and_execute_tasks(
     task_service: &SqliteTaskService,
     mcp_address: Option<std::net::SocketAddr>,
@@ -321,32 +295,25 @@ async fn execute_task_acp(
     context_prompt: Option<&str>,
     bundled_acp_path: Option<&std::path::Path>,
 ) -> Result<(), String> {
-    use agent_client_protocol::Agent as _;
-
     tracing::info!(
         "AgentScheduler: Preparing task context for task {}: '{}'",
         task.id,
         task.title
     );
 
-    // Get MCP server address (shared across all tasks)
-    let (mcp_host, mcp_port) = if let Some(addr) = mcp_address {
-        let host = addr.ip().to_string();
-        let port = addr.port();
+    if let Some(addr) = mcp_address {
         tracing::info!(
             "🔗 [MCP] Using shared server at http://{}:{}/mcp for task {}",
-            host,
-            port,
+            addr.ip(),
+            addr.port(),
             task.id
         );
-        (host, port)
     } else {
         tracing::warn!(
             "⚠️ [MCP] No MCP server configured for task {}, agents will run without tools",
             task.id
         );
-        ("127.0.0.1".to_string(), 0)
-    };
+    }
 
     let comments = task_service
         .get_task_activity(&task.id, TASK_CONTEXT_ACTIVITY_LIMIT)
@@ -379,221 +346,39 @@ async fn execute_task_acp(
         "comments": build_task_comment_context(&comments)
     });
 
-    tracing::info!(
-        "AgentScheduler: Spawning peekoo-agent-acp subprocess for task {}",
-        task.id
-    );
+    let prompt_json = serde_json::to_string(&task_context)
+        .map_err(|e| format!("Failed to serialize task context: {e}"))?;
 
-    let command_path = resolve_acp_command_path(
+    let mut content_blocks = Vec::new();
+    if let Some(ctx) = context_prompt {
+        content_blocks.push(ContentBlock::Text(TextContent::new(ctx.to_string())));
+    }
+    content_blocks.push(ContentBlock::Text(TextContent::new(prompt_json)));
+
+    let prompt_result = crate::acp_client::run_prompt_and_collect(
+        &format!("task-execution:{}", task.id),
+        content_blocks,
+        launch_env.to_vec(),
+        mcp_address,
         bundled_acp_path.map(std::path::Path::to_path_buf),
-        std::env::current_exe().ok(),
-    );
-
-    // Pass MCP server address via environment variables
-    let mut cmd = Command::new(&command_path);
-    if mcp_address.is_some() {
-        cmd.env("PEEKOO_MCP_PORT", mcp_port.to_string())
-            .env("PEEKOO_MCP_HOST", &mcp_host);
-    }
-    for (key, value) in launch_env {
-        cmd.env(key, value);
-    }
-
-    let mut child = match cmd
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::inherit())
-        .spawn()
-    {
-        Ok(child) => {
-            tracing::info!(
-                "AgentScheduler: Successfully spawned {:?} subprocess (pid: {:?})",
-                command_path,
-                child.id()
-            );
-            child
-        }
-        Err(e) => {
-            tracing::error!("AgentScheduler: Failed to spawn {:?}: {}", command_path, e);
-            return Err(format!("Failed to spawn {:?}: {}", command_path, e));
-        }
-    };
-
-    let stdin = child.stdin.take().expect("stdin should be available");
-    let stdout = child.stdout.take().expect("stdout should be available");
+        None,
+    )
+    .await
+    .map_err(|e| format!("ACP execution error: {e}"))?;
 
     tracing::info!(
-        "AgentScheduler: Setting up ACP LocalSet for task {}",
-        task.id
+        "AgentScheduler: ACP prompt completed for task {} - stop_reason: {:?}",
+        task.id,
+        prompt_result.stop_reason
     );
-    let local_set = LocalSet::new();
-
-    let task_id_for_spawn = task.id.clone();
-    let task_id_for_logs = task.id.clone();
-
-    let _stop_reason = match local_set
-        .run_until(async move {
-            let task_id = task_id_for_logs.clone();
-            tracing::info!(
-                "AgentScheduler: Creating ClientSideConnection for task {}",
-                task_id
-            );
-
-            let (conn, handle_io) = ClientSideConnection::new(
-                TaskClient {
-                    task_id: task_id.clone(),
-                },
-                stdin.compat_write(),
-                stdout.compat(),
-                |fut| {
-                    tokio::task::spawn_local(fut);
-                },
-            );
-
-            let task_id_spawn = task_id.clone();
-            tokio::task::spawn_local(async move {
-                if let Err(e) = handle_io.await {
-                    tracing::error!(
-                        "AgentScheduler: ACP I/O error for task {}: {}",
-                        task_id_spawn,
-                        e
-                    );
-                }
-            });
-
-            tracing::info!(
-                "AgentScheduler: Sending ACP initialize request for task {}",
-                task_id
-            );
-            let init_result = conn
-                .initialize(InitializeRequest::new(ProtocolVersion::V1))
-                .await
-                .map_err(|e| {
-                    tracing::error!(
-                        "AgentScheduler: ACP initialize failed for task {}: {}",
-                        task_id,
-                        e
-                    );
-                    format!("ACP initialize error: {}", e)
-                })?;
-
-            tracing::info!(
-                "AgentScheduler: ACP initialize successful for task {} - agent: {:?}",
-                task_id,
-                init_result.agent_info
-            );
-
-            tracing::info!("AgentScheduler: Creating ACP session for task {}", task_id);
-            let mcp_servers = build_session_mcp_servers(mcp_address);
-            let session = conn
-                .new_session(
-                    NewSessionRequest::new(std::env::current_dir().unwrap_or_default())
-                        .mcp_servers(mcp_servers),
-                )
-                .await
-                .map_err(|e| {
-                    tracing::error!(
-                        "AgentScheduler: ACP new_session failed for task {}: {}",
-                        task_id,
-                        e
-                    );
-                    format!("ACP new_session error: {}", e)
-                })?;
-
-            tracing::info!(
-                "AgentScheduler: ACP session created for task {} - session_id: {}",
-                task_id,
-                session.session_id
-            );
-
-            let prompt_json = serde_json::to_string(&task_context).map_err(|e| {
-                tracing::error!(
-                    "AgentScheduler: Failed to serialize task context for task {}: {}",
-                    task_id,
-                    e
-                );
-                format!("Failed to serialize task context: {}", e)
-            })?;
-
-            tracing::info!(
-                "AgentScheduler: Sending ACP prompt to agent for task {} (context size: {} bytes)",
-                task_id,
-                prompt_json.len()
-            );
-
-            // Build content blocks: context prompt first, then task context
-            let mut content_blocks = Vec::new();
-            if let Some(ctx) = context_prompt {
-                content_blocks.push(ContentBlock::Text(TextContent::new(ctx.to_string())));
-            }
-            content_blocks.push(ContentBlock::Text(TextContent::new(prompt_json)));
-
-            let prompt_response = conn
-                .prompt(PromptRequest::new(session.session_id, content_blocks))
-                .await
-                .map_err(|e| {
-                    tracing::error!(
-                        "AgentScheduler: ACP prompt failed for task {}: {}",
-                        task_id,
-                        e
-                    );
-                    format!("ACP prompt error: {}", e)
-                })?;
-
-            tracing::info!(
-                "AgentScheduler: ACP prompt completed for task {} - stop_reason: {:?}",
-                task_id,
-                prompt_response.stop_reason
-            );
-
-            Ok::<_, String>(prompt_response.stop_reason)
-        })
-        .await
-    {
-        Ok(reason) => {
-            tracing::info!(
-                "AgentScheduler: ACP communication completed successfully for task {}",
-                task_id_for_spawn
-            );
-            reason
-        }
-        Err(e) => {
-            tracing::error!(
-                "AgentScheduler: ACP execution error for task {}: {}",
-                task_id_for_spawn,
-                e
-            );
-            return Err(format!("ACP execution error: {}", e));
-        }
-    };
-
-    let task_id_final = task.id.clone();
-
-    tracing::info!(
-        "AgentScheduler: Cleaning up ACP subprocess for task {}",
-        task_id_final
-    );
-    drop(local_set);
-
-    match child.kill().await {
-        Ok(_) => tracing::info!(
-            "AgentScheduler: Successfully killed peekoo-agent-acp subprocess for task {}",
-            task_id_final
-        ),
-        Err(e) => tracing::warn!(
-            "AgentScheduler: Error killing subprocess for task {}: {}",
-            task_id_final,
-            e
-        ),
-    }
 
     tracing::info!(
         "AgentScheduler: Updating task {} agent_work_status to completed",
-        task_id_final
+        task.id
     );
 
     let final_activity_count = task_service
-        .get_task_activity(&task_id_final, 100)
+        .get_task_activity(&task.id, 100)
         .map(|events| events.len())
         .unwrap_or(initial_activity_count);
     if final_activity_count <= initial_activity_count {
@@ -602,35 +387,20 @@ async fn execute_task_acp(
         );
     }
 
-    if let Err(e) = task_service.update_agent_work_status(&task_id_final, "completed", None) {
+    if let Err(e) = task_service.update_agent_work_status(&task.id, "completed", None) {
         tracing::error!(
             "AgentScheduler: Failed to update task {} agent_work_status to completed: {}",
-            task_id_final,
+            task.id,
             e
         );
     }
 
     tracing::info!(
         "AgentScheduler: Task {} execution completed successfully",
-        task_id_final
+        task.id
     );
 
     Ok(())
-}
-
-pub(crate) fn build_session_mcp_servers(
-    mcp_address: Option<std::net::SocketAddr>,
-) -> Vec<McpServer> {
-    mcp_address
-        .map(|addr| {
-            let base_url = peekoo_mcp_server::mcp_url_for(addr);
-            let plugins_url = format!("{}/plugins", base_url);
-            vec![
-                McpServer::Http(McpServerHttp::new("peekoo-native-tools", base_url)),
-                McpServer::Http(McpServerHttp::new("peekoo-plugin-tools", plugins_url)),
-            ]
-        })
-        .unwrap_or_default()
 }
 
 fn build_task_comment_context(events: &[peekoo_task_app::TaskEventDto]) -> Vec<serde_json::Value> {
@@ -658,17 +428,8 @@ fn build_task_comment_context(events: &[peekoo_task_app::TaskEventDto]) -> Vec<s
 
 #[cfg(test)]
 mod tests {
-    use super::{build_session_mcp_servers, build_task_comment_context, resolve_acp_command_path};
+    use super::build_task_comment_context;
     use peekoo_task_app::TaskEventDto;
-
-    #[test]
-    fn builds_http_mcp_server_for_session() {
-        let servers = build_session_mcp_servers(Some(([127, 0, 0, 1], 49152).into()));
-        let serialized = serde_json::to_value(&servers).expect("serialize mcp servers");
-        assert_eq!(serialized[0]["type"], "http");
-        assert_eq!(serialized[0]["name"], "peekoo-native-tools");
-        assert_eq!(serialized[0]["url"], "http://127.0.0.1:49152/mcp");
-    }
 
     #[test]
     fn builds_comment_context_from_comment_events_only_in_chronological_order() {
@@ -702,116 +463,5 @@ mod tests {
         assert_eq!(comments[0]["id"], "comment-1");
         assert_eq!(comments[1]["id"], "comment-2");
         assert_eq!(comments[1]["text"], "@peekoo-agent follow up");
-    }
-
-    #[test]
-    fn resolve_acp_command_path_prefers_explicit_bundled_path() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let bundled = temp.path().join("peekoo-agent-acp");
-        std::fs::write(&bundled, "").expect("create bundled binary");
-
-        let resolved =
-            resolve_acp_command_path(Some(bundled.clone()), Some(temp.path().join("desktop")));
-
-        assert_eq!(resolved, bundled);
-    }
-
-    #[test]
-    fn resolve_acp_command_path_uses_sibling_binary_when_present() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let exe_dir = temp.path().join("bin");
-        std::fs::create_dir_all(&exe_dir).expect("create bin dir");
-        let current_exe = exe_dir.join("peekoo-desktop");
-        let sibling = exe_dir.join(if cfg!(windows) {
-            "peekoo-agent-acp.exe"
-        } else {
-            "peekoo-agent-acp"
-        });
-        std::fs::write(&sibling, "").expect("create sibling binary");
-
-        let resolved = resolve_acp_command_path(None, Some(current_exe));
-
-        assert_eq!(resolved, sibling);
-    }
-}
-
-#[derive(Clone)]
-struct TaskClient {
-    task_id: String,
-}
-
-#[async_trait::async_trait(?Send)]
-impl Client for TaskClient {
-    async fn request_permission(
-        &self,
-        args: agent_client_protocol::RequestPermissionRequest,
-    ) -> Result<agent_client_protocol::RequestPermissionResponse, agent_client_protocol::Error>
-    {
-        tracing::debug!(
-            "AgentScheduler: Agent requested permission for task {} - selecting first allow option if available",
-            self.task_id
-        );
-        if let Some(option) = args.options.iter().find(|option| {
-            matches!(
-                option.kind,
-                agent_client_protocol::PermissionOptionKind::AllowOnce
-                    | agent_client_protocol::PermissionOptionKind::AllowAlways
-            )
-        }) {
-            Ok(agent_client_protocol::RequestPermissionResponse::new(
-                agent_client_protocol::RequestPermissionOutcome::Selected(
-                    agent_client_protocol::SelectedPermissionOutcome::new(option.option_id.clone()),
-                ),
-            ))
-        } else {
-            Ok(agent_client_protocol::RequestPermissionResponse::new(
-                agent_client_protocol::RequestPermissionOutcome::Cancelled,
-            ))
-        }
-    }
-
-    async fn session_notification(
-        &self,
-        args: agent_client_protocol::SessionNotification,
-    ) -> Result<(), agent_client_protocol::Error> {
-        match &args.update {
-            agent_client_protocol::SessionUpdate::AgentMessageChunk(chunk) => {
-                if let agent_client_protocol::ContentBlock::Text(text) = &chunk.content {
-                    tracing::info!(
-                        "AgentScheduler: Agent message for task {}: {}",
-                        self.task_id,
-                        text.text.chars().take(200).collect::<String>()
-                    );
-                } else {
-                    tracing::debug!(
-                        "AgentScheduler: Agent sent non-text content for task {}",
-                        self.task_id
-                    );
-                }
-            }
-            agent_client_protocol::SessionUpdate::ToolCall(tool_call) => {
-                tracing::info!(
-                    "AgentScheduler: Agent tool call for task {}: {} - {:?}",
-                    self.task_id,
-                    tool_call.title,
-                    tool_call.kind
-                );
-            }
-            agent_client_protocol::SessionUpdate::ToolCallUpdate(update) => {
-                tracing::info!(
-                    "AgentScheduler: Agent tool call update for task {}: {:?}",
-                    self.task_id,
-                    update.fields
-                );
-            }
-            _ => {
-                tracing::debug!(
-                    "AgentScheduler: Received session update for task {}: {:?}",
-                    self.task_id,
-                    args.update
-                );
-            }
-        }
-        Ok(())
     }
 }

--- a/crates/peekoo-agent-app/src/application.rs
+++ b/crates/peekoo-agent-app/src/application.rs
@@ -56,6 +56,7 @@ use peekoo_task_app::SqliteTaskService;
 use crate::workspace_bootstrap::ensure_agent_workspace;
 
 type TaskChangeCallback = Arc<dyn Fn(Option<String>) + Send + Sync>;
+const TASK_PARSE_ACP_TIMEOUT_SECS: u64 = 12;
 
 fn format_error_chain(err: &dyn std::error::Error) -> String {
     let mut chain = Vec::new();
@@ -95,6 +96,54 @@ fn build_task_runtime_launch_env(config: &AgentServiceConfig) -> Vec<(String, St
     env
 }
 
+fn normalize_priority(priority: Option<String>) -> Option<String> {
+    match priority.as_deref().map(str::trim).filter(|v| !v.is_empty()) {
+        Some("high") | Some("medium") | Some("low") => priority,
+        _ => None,
+    }
+}
+
+fn normalize_assignee(assignee: Option<String>) -> Option<String> {
+    match assignee.as_deref().map(str::trim).filter(|v| !v.is_empty()) {
+        Some("user") | Some("agent") => assignee,
+        _ => None,
+    }
+}
+
+fn normalize_optional_trimmed(value: Option<String>) -> Option<String> {
+    value.and_then(|v| {
+        let trimmed = v.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
+}
+
+fn parse_rfc3339_or_none(value: Option<String>) -> Option<String> {
+    let trimmed = normalize_optional_trimmed(value)?;
+    chrono::DateTime::parse_from_rfc3339(&trimmed)
+        .ok()
+        .map(|dt| dt.with_timezone(&chrono::Utc).to_rfc3339())
+}
+
+fn extract_json_object(text: &str) -> Option<&str> {
+    let start = text.find('{')?;
+    let end = text.rfind('}')?;
+    (start < end).then(|| &text[start..=end])
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct AcpParsedTask {
+    title: String,
+    priority: Option<String>,
+    assignee: Option<String>,
+    labels: Option<Vec<String>>,
+    description: Option<String>,
+    scheduled_start_at: Option<String>,
+    scheduled_end_at: Option<String>,
+    estimated_duration_min: Option<u32>,
+    recurrence_rule: Option<String>,
+    recurrence_time_of_day: Option<String>,
+}
+
 pub struct AgentApplication {
     agent: Arc<Mutex<Option<AgentService>>>,
     settings: SettingsService,
@@ -124,6 +173,7 @@ pub struct AgentApplication {
     /// Scheduler for agent task execution.
     agent_scheduler: Arc<Mutex<Option<crate::agent_scheduler::AgentScheduler>>>,
     bundled_opencode_path: Option<PathBuf>,
+    bundled_acp_path: Option<PathBuf>,
     /// Directory containing the bundled Node.js binary (e.g. `<resources>/opencode/node/bin`).
     bundled_node_bin_dir: Option<PathBuf>,
 }
@@ -232,6 +282,7 @@ impl AgentApplication {
             conversation_generation: AtomicU64::new(0),
             agent_scheduler: Arc::new(Mutex::new(Some(agent_scheduler))),
             bundled_opencode_path,
+            bundled_acp_path,
             bundled_node_bin_dir,
         })
     }
@@ -843,7 +894,9 @@ impl AgentApplication {
     pub fn create_task_from_text(&self, text: &str) -> Result<TaskDto, String> {
         use crate::task_parser::parse_task_text;
 
-        let parsed = parse_task_text(text);
+        let parsed = self
+            .parse_task_from_text_via_acp(text)
+            .unwrap_or_else(|_| parse_task_text(text));
 
         self.task_runtime_service().create_task(
             &parsed.title,
@@ -857,6 +910,66 @@ impl AgentApplication {
             parsed.recurrence_rule.as_deref(),
             parsed.recurrence_time_of_day.as_deref(),
         )
+    }
+
+    fn parse_task_from_text_via_acp(
+        &self,
+        text: &str,
+    ) -> Result<crate::task_parser::ParsedTask, String> {
+        let parse_payload = serde_json::json!({
+            "request_type": "task_creation_parse",
+            "raw_text": text,
+            "locale": self.get_app_language().ok(),
+            "timezone": std::env::var("TZ").ok(),
+        });
+
+        let parse_payload = serde_json::to_string(&parse_payload)
+            .map_err(|e| format!("Serialize parse payload error: {e}"))?;
+
+        let prompt_result = crate::acp_client::run_prompt_and_collect_blocking(
+            "task-creation-parse",
+            vec![agent_client_protocol::ContentBlock::Text(
+                agent_client_protocol::TextContent::new(parse_payload),
+            )],
+            self.agent_launch_env(),
+            crate::mcp_server::get_mcp_address(),
+            self.bundled_acp_path.clone(),
+            Some(std::time::Duration::from_secs(TASK_PARSE_ACP_TIMEOUT_SECS)),
+        )?;
+
+        let raw = prompt_result.text;
+        let json_blob = extract_json_object(&raw)
+            .ok_or_else(|| "ACP parser returned no JSON object".to_string())?;
+        let acp_parsed: AcpParsedTask =
+            serde_json::from_str(json_blob).map_err(|e| format!("Parse task JSON error: {e}"))?;
+
+        let title = acp_parsed.title.trim();
+        if title.is_empty() {
+            return Err("ACP parser returned empty title".to_string());
+        }
+
+        let mut labels = acp_parsed
+            .labels
+            .unwrap_or_default()
+            .into_iter()
+            .map(|label| label.trim().to_lowercase())
+            .filter(|label| !label.is_empty())
+            .collect::<Vec<_>>();
+        labels.sort();
+        labels.dedup();
+
+        Ok(crate::task_parser::ParsedTask {
+            title: title.to_string(),
+            priority: normalize_priority(acp_parsed.priority),
+            assignee: normalize_assignee(acp_parsed.assignee),
+            labels,
+            description: normalize_optional_trimmed(acp_parsed.description),
+            scheduled_start_at: parse_rfc3339_or_none(acp_parsed.scheduled_start_at),
+            scheduled_end_at: parse_rfc3339_or_none(acp_parsed.scheduled_end_at),
+            estimated_duration_min: acp_parsed.estimated_duration_min,
+            recurrence_rule: normalize_optional_trimmed(acp_parsed.recurrence_rule),
+            recurrence_time_of_day: normalize_optional_trimmed(acp_parsed.recurrence_time_of_day),
+        })
     }
 
     pub fn get_task_activity(
@@ -1413,7 +1526,7 @@ impl AgentApplication {
         }
 
         config.mcp_servers =
-            crate::agent_scheduler::build_session_mcp_servers(crate::mcp_server::get_mcp_address());
+            crate::acp_client::build_session_mcp_servers(crate::mcp_server::get_mcp_address());
 
         // If get_last_session stashed a path, resume that session for full
         // context restore. The path is consumed so it is only used once.
@@ -1693,6 +1806,7 @@ mod tests {
 
     use super::{
         build_task_runtime_launch_env, format_error_chain, install_discovered_plugins,
+        normalize_assignee, normalize_optional_trimmed, normalize_priority, parse_rfc3339_or_none,
         should_restore_agent,
     };
     use std::error::Error as StdError;
@@ -1834,6 +1948,42 @@ mod tests {
         )));
         assert!(env.contains(&("PEEKOO_AGENT_MODEL".to_string(), "test-model".to_string())));
         assert!(env.contains(&("PEEKOO_AGENT_API_KEY".to_string(), "secret".to_string())));
+    }
+
+    #[test]
+    fn normalize_priority_accepts_only_known_values() {
+        assert_eq!(normalize_priority(Some("high".into())), Some("high".into()));
+        assert_eq!(normalize_priority(Some("urgent".into())), None);
+        assert_eq!(normalize_priority(Some("".into())), None);
+    }
+
+    #[test]
+    fn normalize_assignee_accepts_only_user_or_agent() {
+        assert_eq!(normalize_assignee(Some("user".into())), Some("user".into()));
+        assert_eq!(
+            normalize_assignee(Some("agent".into())),
+            Some("agent".into())
+        );
+        assert_eq!(normalize_assignee(Some("team".into())), None);
+    }
+
+    #[test]
+    fn normalize_optional_trimmed_drops_empty_values() {
+        assert_eq!(
+            normalize_optional_trimmed(Some("  hello  ".into())),
+            Some("hello".into())
+        );
+        assert_eq!(normalize_optional_trimmed(Some("   ".into())), None);
+        assert_eq!(normalize_optional_trimmed(None), None);
+    }
+
+    #[test]
+    fn parse_rfc3339_or_none_normalizes_valid_timestamp() {
+        assert_eq!(
+            parse_rfc3339_or_none(Some("2026-04-11T10:00:00+02:00".into())),
+            Some("2026-04-11T08:00:00+00:00".into())
+        );
+        assert_eq!(parse_rfc3339_or_none(Some("not-a-date".into())), None);
     }
 
     fn test_registry(plugin_name: &str) -> Arc<PluginRegistry> {

--- a/crates/peekoo-agent-app/src/lib.rs
+++ b/crates/peekoo-agent-app/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod acp_client;
 pub mod agent_provider_commands;
 pub mod agent_provider_service;
 pub mod agent_runtime_commands;


### PR DESCRIPTION
## What changed

- Add ACP task-creation parse mode in `peekoo-agent-acp` (`task_creation_parse`) with strict JSON prompt contract.
- Route `create_task_from_text` through ACP prompt parsing first, with permanent fallback to the local regex parser.
- Add parser safety: timeout, enum normalization (`priority`, `assignee`), label cleanup, optional string trimming, RFC3339 timestamp validation/normalization.
- Extract ACP subprocess/session/prompt orchestration into shared `acp_client` and reuse it from scheduler execution and task-creation parsing.
- Add/update plan and changelog docs under `ai/plans` and `ai/memories/changelogs`.
- Ignore local `.opencode/` artifacts via `.gitignore`.

## Release notes

- [x] Add at least one release-note label: `feature`, `fix`, `docs`, `test`, `chore`, `ci`, or `refactor`
- [ ] Use `skip-changelog` if this PR should be excluded from generated release notes

## Verification

- [x] Tests pass locally
- [x] `just fmt`
- [x] `just lint` (clippy)
- [x] `just check`