### PR TITLE
feat(updater): render markdown release notes in dedicated update panel

### DIFF
--- a/ai/memories/changelogs/202604111515-fix-updater-markdown-release-notes.md
+++ b/ai/memories/changelogs/202604111515-fix-updater-markdown-release-notes.md
@@ -1,0 +1,30 @@
+## 2026-04-11 15:15: fix: render updater release notes as markdown in in-app dialog
+
+**What changed:**
+- Replaced native updater confirmation prompt usage (`@tauri-apps/plugin-dialog` `ask`) with an in-app update dialog that renders release notes via `Streamdown`.
+- Added release-note normalization utility to strip leading generated HTML comments, normalize newlines, and trim empty content before rendering.
+- Refactored updater flow to separate concerns: check for update metadata (`checkForAppUpdates`) and install/relaunch action (`installAppUpdate`).
+- Wired the main app window to fetch update metadata on startup and show the new dialog, including install-in-progress and install-error states.
+- Added update download/install progress UI in the dialog using Tauri updater download events (`Started`, `Progress`, `Finished`), with percentage and byte counters.
+- Added estimated remaining download time (ETA) based on observed throughput and elapsed download time.
+- Added a "View full changelog" action that opens the GitHub release page in the system browser.
+- Added a dev-only forced updater dialog mode (via Vite env vars) so markdown rendering and changelog-link UI can be tested quickly in local dev without publishing a real update.
+- Moved updater UX into a dedicated `panel-updater` window (larger dimensions) so markdown changelog content is readable on small sprite/main window sizes.
+- Added/updated tests and i18n keys for updater dialog copy (`versionAvailable`, `installing`).
+
+**Why:**
+- GitHub release notes are markdown; native system dialogs only support plain text, causing malformed changelog rendering in the update popup.
+- The in-app dialog preserves markdown structure and links, improving readability and update UX.
+
+**Files affected:**
+- `apps/desktop-ui/src/lib/updater.ts`
+- `apps/desktop-ui/src/lib/release-notes.ts`
+- `apps/desktop-ui/src/lib/release-notes.test.ts`
+- `apps/desktop-ui/src/features/about/UpdatePromptDialog.tsx`
+- `apps/desktop-ui/src/main.tsx`
+- `apps/desktop-ui/src/locales/en.json`
+- `apps/desktop-ui/src/locales/ja.json`
+- `apps/desktop-ui/src/locales/zh.json`
+- `apps/desktop-ui/src/locales/zh-TW.json`
+- `apps/desktop-ui/src/locales/es.json`
+- `apps/desktop-ui/src/locales/fr.json`

--- a/apps/desktop-ui/src/env.d.ts
+++ b/apps/desktop-ui/src/env.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_FORCE_UPDATER_DIALOG?: string;
+  readonly VITE_FORCE_UPDATER_VERSION?: string;
+  readonly VITE_FORCE_UPDATER_NOTES?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/apps/desktop-ui/src/features/about/UpdatePromptDialog.tsx
+++ b/apps/desktop-ui/src/features/about/UpdatePromptDialog.tsx
@@ -146,7 +146,7 @@ export function UpdatePromptDialog({
           ) : null}
 
           {updateInfo?.body ? (
-            <div className="text-sm leading-6 text-text-primary [&_h2]:mt-4 [&_h2]:text-base [&_h2]:font-semibold [&_h2]:text-text-primary [&_h3]:mt-3 [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:text-text-primary [&_p]:my-2 [&_ul]:my-2 [&_ul]:pl-5 [&_ol]:my-2 [&_ol]:pl-5 [&_li]:my-1 [&_a]:text-glow-green [&_a]:underline [&_code]:rounded-md [&_code]:bg-space-overlay/70 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:text-[0.85em] [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:border [&_pre]:border-glass-border/70 [&_pre]:bg-space-deep/70 [&_pre]:p-3">
+            <div className="text-sm leading-6 text-text-primary [&_h2]:mt-4 [&_h2]:text-base [&_h2]:font-semibold [&_h2]:text-text-primary [&_h3]:mt-3 [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:text-text-primary [&_p]:my-2 [&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-2 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:my-1 [&_a]:text-glow-green [&_a]:underline [&_code]:rounded-md [&_code]:bg-space-overlay/70 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:text-[0.85em] [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-space-deep/70">
               <Streamdown>{updateInfo.body}</Streamdown>
             </div>
           ) : (

--- a/apps/desktop-ui/src/features/about/UpdatePromptDialog.tsx
+++ b/apps/desktop-ui/src/features/about/UpdatePromptDialog.tsx
@@ -1,0 +1,176 @@
+import { useMemo } from "react";
+import { Streamdown } from "streamdown";
+import { Button } from "@/components/ui/button";
+import { invoke } from "@tauri-apps/api/core";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { AppUpdateInfo } from "@/lib/updater";
+import { useTranslation } from "react-i18next";
+
+interface UpdatePromptDialogProps {
+  updateInfo: AppUpdateInfo | null;
+  isInstalling: boolean;
+  installError: string | null;
+  installPhase: "idle" | "downloading" | "installing";
+  downloadedBytes: number;
+  totalBytes: number | null;
+  progressPercent: number | null;
+  etaSeconds: number | null;
+  onInstall: () => void;
+  onLater: () => void;
+}
+
+function formatBytes(value: number): string {
+  if (value < 1024) {
+    return `${value} B`;
+  }
+
+  const units = ["KB", "MB", "GB"];
+  let size = value / 1024;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${size.toFixed(1)} ${units[unitIndex]}`;
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+
+  const minutes = Math.floor(seconds / 60);
+  const remain = seconds % 60;
+  return `${minutes}m ${remain}s`;
+}
+
+export function UpdatePromptDialog({
+  updateInfo,
+  isInstalling,
+  installError,
+  installPhase,
+  downloadedBytes,
+  totalBytes,
+  progressPercent,
+  etaSeconds,
+  onInstall,
+  onLater,
+}: UpdatePromptDialogProps) {
+  const { t } = useTranslation();
+
+  const fallbackMessage = useMemo(() => {
+    if (!updateInfo) {
+      return "";
+    }
+
+    return t("updater.message", { version: updateInfo.version });
+  }, [t, updateInfo]);
+
+  async function openFullChangelog() {
+    if (!updateInfo) {
+      return;
+    }
+
+    try {
+      await invoke("system_open_url", { url: updateInfo.releaseUrl });
+    } catch (error) {
+      console.error("Failed to open release page:", error);
+    }
+  }
+
+  return (
+    <Dialog
+      open={updateInfo !== null}
+      onOpenChange={(open) => {
+        if (!open && updateInfo) {
+          onLater();
+        }
+      }}
+    >
+      <DialogContent className="max-w-2xl border border-glass-border bg-space-void/95 p-0 text-text-primary backdrop-blur-xl">
+        <DialogHeader className="space-y-2 border-b border-glass-border/70 px-6 py-5">
+          <DialogTitle className="text-xl text-text-primary">{t("updater.title")}</DialogTitle>
+          <DialogDescription className="text-sm text-text-muted">
+            {updateInfo ? t("updater.versionAvailable", { version: updateInfo.version }) : ""}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-[52vh] overflow-y-auto px-6 py-4 custom-scrollbar">
+          {isInstalling ? (
+            <div className="mb-4 rounded-lg border border-glass-border/70 bg-space-overlay/45 px-3 py-3">
+              <div className="mb-2 flex items-center justify-between gap-2 text-xs text-text-muted">
+                <span>
+                  {installPhase === "installing"
+                    ? t("updater.installingFiles")
+                    : t("updater.downloading")}
+                </span>
+                <span>
+                  {progressPercent !== null ? `${progressPercent}%` : t("updater.calculating")}
+                </span>
+              </div>
+              <div className="h-2 w-full overflow-hidden rounded-full bg-space-deep/90">
+                <div
+                  className="h-full rounded-full bg-gradient-primary transition-[width] duration-200"
+                  style={{ width: `${progressPercent ?? 15}%` }}
+                />
+              </div>
+              {installPhase !== "installing" ? (
+                <div className="mt-2 space-y-1">
+                  <p className="text-xs text-text-muted">
+                    {totalBytes
+                      ? t("updater.downloadedDetail", {
+                          downloaded: formatBytes(downloadedBytes),
+                          total: formatBytes(totalBytes),
+                        })
+                      : t("updater.downloadedOnly", { downloaded: formatBytes(downloadedBytes) })}
+                  </p>
+                  {etaSeconds !== null ? (
+                    <p className="text-xs text-text-muted">
+                      {t("updater.eta", { eta: formatDuration(etaSeconds) })}
+                    </p>
+                  ) : null}
+                </div>
+              ) : (
+                <p className="mt-2 text-xs text-text-muted">{t("updater.restartSoon")}</p>
+              )}
+            </div>
+          ) : null}
+
+          {updateInfo?.body ? (
+            <div className="text-sm leading-6 text-text-primary [&_h2]:mt-4 [&_h2]:text-base [&_h2]:font-semibold [&_h2]:text-text-primary [&_h3]:mt-3 [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:text-text-primary [&_p]:my-2 [&_ul]:my-2 [&_ul]:pl-5 [&_ol]:my-2 [&_ol]:pl-5 [&_li]:my-1 [&_a]:text-glow-green [&_a]:underline [&_code]:rounded-md [&_code]:bg-space-overlay/70 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:text-[0.85em] [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:border [&_pre]:border-glass-border/70 [&_pre]:bg-space-deep/70 [&_pre]:p-3">
+              <Streamdown>{updateInfo.body}</Streamdown>
+            </div>
+          ) : (
+            <p className="text-sm leading-6 text-text-primary">{fallbackMessage}</p>
+          )}
+          {installError ? (
+            <p className="mt-4 rounded-lg border border-danger/40 bg-danger/10 px-3 py-2 text-sm text-danger">
+              {installError}
+            </p>
+          ) : null}
+        </div>
+
+        <DialogFooter className="gap-2 border-t border-glass-border/70 px-6 py-4 sm:justify-end">
+          <Button variant="ghost" onClick={() => void openFullChangelog()} disabled={!updateInfo || isInstalling}>
+            {t("updater.viewFullChangelog")}
+          </Button>
+          <Button variant="glass" onClick={onLater} disabled={isInstalling}>
+            {t("updater.later")}
+          </Button>
+          <Button variant="success" onClick={onInstall} disabled={isInstalling || !updateInfo || !updateInfo.update}>
+            {isInstalling ? t("updater.installing") : t("updater.installButton")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop-ui/src/hooks/use-panel-windows.ts
+++ b/apps/desktop-ui/src/hooks/use-panel-windows.ts
@@ -20,6 +20,7 @@ const INITIAL_STATE: PanelWindowStates = {
   "panel-pomodoro": { isOpen: false },
   "panel-plugins": { isOpen: false },
   "panel-settings": { isOpen: false },
+  "panel-updater": { isOpen: false },
 };
 
 const PANEL_OFFSET_X = 20;

--- a/apps/desktop-ui/src/lib/release-notes.test.ts
+++ b/apps/desktop-ui/src/lib/release-notes.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeReleaseNotes } from "./release-notes";
+
+describe("normalizeReleaseNotes", () => {
+  test("returns null for missing notes", () => {
+    expect(normalizeReleaseNotes(null)).toBeNull();
+    expect(normalizeReleaseNotes(undefined)).toBeNull();
+    expect(normalizeReleaseNotes("   ")).toBeNull();
+  });
+
+  test("normalizes line endings and trims whitespace", () => {
+    const result = normalizeReleaseNotes("\r\n  ## Title\r\n- item\r\n  ");
+
+    expect(result).toBe("## Title\n- item");
+  });
+
+  test("removes leading html comments from generated release notes", () => {
+    const notes = "<!-- generated -->\n\n## What's Changed\n- one";
+
+    expect(normalizeReleaseNotes(notes)).toBe("## What's Changed\n- one");
+  });
+});

--- a/apps/desktop-ui/src/lib/release-notes.ts
+++ b/apps/desktop-ui/src/lib/release-notes.ts
@@ -1,0 +1,18 @@
+const LEADING_HTML_COMMENT_PATTERN = /^\s*<!--[\s\S]*?-->\s*/;
+
+export function normalizeReleaseNotes(notes?: string | null): string | null {
+  if (!notes) {
+    return null;
+  }
+
+  const normalized = notes
+    .replace(/\r\n/g, "\n")
+    .replace(LEADING_HTML_COMMENT_PATTERN, "")
+    .trim();
+
+  if (!normalized) {
+    return null;
+  }
+
+  return normalized;
+}

--- a/apps/desktop-ui/src/lib/updater.ts
+++ b/apps/desktop-ui/src/lib/updater.ts
@@ -36,7 +36,7 @@ function buildDevMockUpdateInfo(): AppUpdateInfo {
   const version = import.meta.env.VITE_FORCE_UPDATER_VERSION || "0.1.99-dev";
   const notes = normalizeReleaseNotes(
     import.meta.env.VITE_FORCE_UPDATER_NOTES ||
-      "## What's Changed\n- Added markdown release notes rendering\n- Added installer progress bar with ETA\n\n```bash\n# dev mock update\npeekoo --self-update\n```",
+      "## What's Changed\n- Added markdown release notes rendering\n- Added installer progress bar with ETA\n- Added full changelog link",
   );
 
   return {

--- a/apps/desktop-ui/src/lib/updater.ts
+++ b/apps/desktop-ui/src/lib/updater.ts
@@ -1,24 +1,58 @@
-import { ask } from "@tauri-apps/plugin-dialog";
 import { relaunch } from "@tauri-apps/plugin-process";
-import { check } from "@tauri-apps/plugin-updater";
-import i18next from "i18next";
+import { check, type DownloadEvent, type Update } from "@tauri-apps/plugin-updater";
+import { normalizeReleaseNotes } from "@/lib/release-notes";
 
 const UPDATE_CHECK_DELAY_MS = 3_000;
 
-function formatUpdateMessage(version: string, notes?: string): string {
-  const trimmedNotes = notes?.trim();
-  const t = i18next.t.bind(i18next);
-
-  if (!trimmedNotes) {
-    return t("updater.message", { version });
-  }
-
-  return t("updater.messageWithNotes", { version, notes: trimmedNotes });
+export interface AppUpdateInfo {
+  version: string;
+  body: string | null;
+  releaseUrl: string;
+  update: Update | null;
 }
 
-export async function checkForAppUpdates(): Promise<void> {
+export interface AppUpdateInstallProgress {
+  phase: "downloading" | "installing";
+  downloadedBytes: number;
+  totalBytes: number | null;
+  percent: number | null;
+}
+
+function resolveReleaseUrl(update: Update): string {
+  const rawUrl = update.rawJson?.html_url;
+  if (typeof rawUrl === "string" && rawUrl.startsWith("http")) {
+    return rawUrl;
+  }
+
+  const tag = update.version.startsWith("v") ? update.version : `v${update.version}`;
+  return `https://github.com/feed-mob/peekoo-ai/releases/tag/${tag}`;
+}
+
+interface CheckForAppUpdatesOptions {
+  forceInDev?: boolean;
+}
+
+function buildDevMockUpdateInfo(): AppUpdateInfo {
+  const version = import.meta.env.VITE_FORCE_UPDATER_VERSION || "0.1.99-dev";
+  const notes = normalizeReleaseNotes(
+    import.meta.env.VITE_FORCE_UPDATER_NOTES ||
+      "## What's Changed\n- Added markdown release notes rendering\n- Added installer progress bar with ETA\n\n```bash\n# dev mock update\npeekoo --self-update\n```",
+  );
+
+  return {
+    version,
+    body: notes,
+    releaseUrl: `https://github.com/feed-mob/peekoo-ai/releases/tag/v${version.replace(/^v/, "")}`,
+    update: null,
+  };
+}
+
+export async function checkForAppUpdates(options?: CheckForAppUpdatesOptions): Promise<AppUpdateInfo | null> {
   if (!import.meta.env.PROD) {
-    return;
+    if (import.meta.env.DEV && options?.forceInDev) {
+      return buildDevMockUpdateInfo();
+    }
+    return null;
   }
 
   await new Promise((resolve) => window.setTimeout(resolve, UPDATE_CHECK_DELAY_MS));
@@ -27,23 +61,25 @@ export async function checkForAppUpdates(): Promise<void> {
     const update = await check();
 
     if (!update) {
-      return;
+      return null;
     }
 
-    const shouldInstall = await ask(formatUpdateMessage(update.version, update.body), {
-      title: i18next.t("updater.title"),
-      kind: "info",
-      okLabel: i18next.t("updater.installButton"),
-      cancelLabel: i18next.t("updater.later"),
-    });
-
-    if (!shouldInstall) {
-      return;
-    }
-
-    await update.downloadAndInstall();
-    await relaunch();
+    return {
+      version: update.version,
+      body: normalizeReleaseNotes(update.body),
+      releaseUrl: resolveReleaseUrl(update),
+      update,
+    };
   } catch (error) {
     console.warn("peekoo updater check failed", error);
+    return null;
   }
+}
+
+export async function installAppUpdate(
+  update: Update,
+  onProgress?: (event: DownloadEvent) => void,
+): Promise<void> {
+  await update.downloadAndInstall(onProgress);
+  await relaunch();
 }

--- a/apps/desktop-ui/src/locales/en.json
+++ b/apps/desktop-ui/src/locales/en.json
@@ -409,7 +409,17 @@
     "title": "Update Available",
     "message": "Peekoo {{version}} is available. Install it now and restart?",
     "messageWithNotes": "Peekoo {{version}} is available.\n\n{{notes}}\n\nInstall it now and restart?",
+    "versionAvailable": "Peekoo {{version}} is available.",
     "installButton": "Install and Restart",
+    "installing": "Installing...",
+    "downloading": "Downloading update",
+    "installingFiles": "Installing update",
+    "calculating": "calculating...",
+    "downloadedDetail": "{{downloaded}} of {{total}} downloaded",
+    "downloadedOnly": "{{downloaded}} downloaded",
+    "eta": "Estimated time left: {{eta}}",
+    "restartSoon": "Restarting app once installation finishes.",
+    "viewFullChangelog": "View full changelog",
     "later": "Later"
   },
   "agentRuntimes": {

--- a/apps/desktop-ui/src/locales/es.json
+++ b/apps/desktop-ui/src/locales/es.json
@@ -409,7 +409,17 @@
     "title": "Actualización disponible",
     "message": "Peekoo {{version}} está disponible. ¿Instalarla ahora y reiniciar?",
     "messageWithNotes": "Peekoo {{version}} está disponible.\n\n{{notes}}\n\n¿Instalarla ahora y reiniciar?",
+    "versionAvailable": "Peekoo {{version}} está disponible.",
     "installButton": "Instalar y reiniciar",
+    "installing": "Instalando...",
+    "downloading": "Descargando actualización",
+    "installingFiles": "Instalando actualización",
+    "calculating": "calculando...",
+    "downloadedDetail": "{{downloaded}} de {{total}} descargados",
+    "downloadedOnly": "{{downloaded}} descargados",
+    "eta": "Tiempo estimado restante: {{eta}}",
+    "restartSoon": "La app se reiniciará al finalizar la instalación.",
+    "viewFullChangelog": "Ver changelog completo",
     "later": "Más tarde"
   },
   "agentRuntimes": {

--- a/apps/desktop-ui/src/locales/fr.json
+++ b/apps/desktop-ui/src/locales/fr.json
@@ -419,7 +419,17 @@
     "title": "Mise à jour disponible",
     "message": "Peekoo {{version}} est disponible. L'installer maintenant et redémarrer ?",
     "messageWithNotes": "Peekoo {{version}} est disponible.\n\n{{notes}}\n\nL'installer maintenant et redémarrer ?",
+    "versionAvailable": "Peekoo {{version}} est disponible.",
     "installButton": "Installer et redémarrer",
+    "installing": "Installation...",
+    "downloading": "Téléchargement de la mise à jour",
+    "installingFiles": "Installation de la mise à jour",
+    "calculating": "calcul en cours...",
+    "downloadedDetail": "{{downloaded}} sur {{total}} téléchargés",
+    "downloadedOnly": "{{downloaded}} téléchargés",
+    "eta": "Temps restant estimé : {{eta}}",
+    "restartSoon": "L'application redémarrera une fois l'installation terminée.",
+    "viewFullChangelog": "Voir le changelog complet",
     "later": "Plus tard"
   },
   "agentRuntimes": {

--- a/apps/desktop-ui/src/locales/ja.json
+++ b/apps/desktop-ui/src/locales/ja.json
@@ -409,7 +409,17 @@
     "title": "更新があります",
     "message": "Peekoo {{version}} が利用可能です。今すぐインストールして再起動しますか？",
     "messageWithNotes": "Peekoo {{version}} が利用可能です。\n\n{{notes}}\n\n今すぐインストールして再起動しますか？",
+    "versionAvailable": "Peekoo {{version}} が利用可能です。",
     "installButton": "インストールして再起動",
+    "installing": "インストール中...",
+    "downloading": "更新をダウンロード中",
+    "installingFiles": "更新をインストール中",
+    "calculating": "計算中...",
+    "downloadedDetail": "{{downloaded}} / {{total}} をダウンロード済み",
+    "downloadedOnly": "{{downloaded}} をダウンロード済み",
+    "eta": "残り時間の目安: {{eta}}",
+    "restartSoon": "インストール完了後にアプリを再起動します。",
+    "viewFullChangelog": "完全なリリースノートを表示",
     "later": "後で"
   },
   "agentRuntimes": {

--- a/apps/desktop-ui/src/locales/zh-TW.json
+++ b/apps/desktop-ui/src/locales/zh-TW.json
@@ -409,7 +409,17 @@
     "title": "有可用更新",
     "message": "Peekoo {{version}} 已可用。立即安裝並重新啟動？",
     "messageWithNotes": "Peekoo {{version}} 已可用。\n\n{{notes}}\n\n立即安裝並重新啟動？",
+    "versionAvailable": "Peekoo {{version}} 已可用。",
     "installButton": "安裝並重新啟動",
+    "installing": "安裝中...",
+    "downloading": "正在下載更新",
+    "installingFiles": "正在安裝更新",
+    "calculating": "計算中...",
+    "downloadedDetail": "已下載 {{downloaded}} / {{total}}",
+    "downloadedOnly": "已下載 {{downloaded}}",
+    "eta": "預估剩餘時間：{{eta}}",
+    "restartSoon": "安裝完成後將自動重新啟動應用程式。",
+    "viewFullChangelog": "查看完整更新日誌",
     "later": "稍後"
   },
   "agentRuntimes": {

--- a/apps/desktop-ui/src/locales/zh.json
+++ b/apps/desktop-ui/src/locales/zh.json
@@ -409,7 +409,17 @@
     "title": "有可用更新",
     "message": "Peekoo {{version}} 已可用。立即安装并重启？",
     "messageWithNotes": "Peekoo {{version}} 已可用。\n\n{{notes}}\n\n立即安装并重启？",
+    "versionAvailable": "Peekoo {{version}} 已可用。",
     "installButton": "安装并重启",
+    "installing": "安装中...",
+    "downloading": "正在下载更新",
+    "installingFiles": "正在安装更新",
+    "calculating": "计算中...",
+    "downloadedDetail": "已下载 {{downloaded}} / {{total}}",
+    "downloadedOnly": "已下载 {{downloaded}}",
+    "eta": "预计剩余时间：{{eta}}",
+    "restartSoon": "安装完成后将自动重启应用。",
+    "viewFullChangelog": "查看完整更新日志",
     "later": "稍后"
   },
   "agentRuntimes": {

--- a/apps/desktop-ui/src/main.tsx
+++ b/apps/desktop-ui/src/main.tsx
@@ -7,6 +7,7 @@ import { forwardConsole } from "@/lib/log";
 import { checkForAppUpdates } from "@/lib/updater";
 import { useSystemTheme } from "@/hooks/use-system-theme";
 import { initI18n, setupLanguageListener } from "@/lib/i18n";
+import { openPanelWindow } from "@/hooks/use-panel-windows";
 import { useEffect } from "react";
 import "./index.css";
 
@@ -15,13 +16,11 @@ if (shouldForwardConsole(import.meta.env.DEV)) {
 }
 
 const label = getCurrentWebviewWindow().label;
-
-if (label === "main") {
-  void checkForAppUpdates();
-}
+const FORCE_UPDATER_IN_DEV = import.meta.env.DEV && import.meta.env.VITE_FORCE_UPDATER_DIALOG === "true";
 
 function App() {
   useSystemTheme();
+
   useEffect(() => {
     let disposed = false;
     let teardown: (() => void) | null = null;
@@ -36,6 +35,26 @@ function App() {
     return () => {
       disposed = true;
       teardown?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (label !== "main") {
+      return;
+    }
+
+    let active = true;
+
+    void checkForAppUpdates({ forceInDev: FORCE_UPDATER_IN_DEV }).then((nextUpdateInfo) => {
+      if (!active || !nextUpdateInfo) {
+        return;
+      }
+
+      void openPanelWindow("panel-updater");
+    });
+
+    return () => {
+      active = false;
     };
   }, []);
 

--- a/apps/desktop-ui/src/routing/resolve-view.tsx
+++ b/apps/desktop-ui/src/routing/resolve-view.tsx
@@ -10,6 +10,7 @@ const PluginsView = lazy(() => import("@/views/PluginsView"));
 const PluginPanelView = lazy(() => import("@/views/PluginPanelView"));
 const SettingsView = lazy(() => import("@/views/SettingsView"));
 const AboutView = lazy(() => import("@/views/AboutView"));
+const UpdaterView = lazy(() => import("@/views/UpdaterView"));
 
 function UnknownView({ label }: { label: string }) {
   return (
@@ -46,6 +47,8 @@ function viewForLabel(label: string) {
       return <SettingsView />;
     case "panel-about":
       return <AboutView />;
+    case "panel-updater":
+      return <UpdaterView />;
   }
 }
 

--- a/apps/desktop-ui/src/types/window.ts
+++ b/apps/desktop-ui/src/types/window.ts
@@ -8,6 +8,7 @@ export const BUILTIN_PANEL_LABELS = [
   "panel-plugins",
   "panel-settings",
   "panel-about",
+  "panel-updater",
 ] as const;
 
 export const WindowLabelSchema = z.string().refine(
@@ -73,5 +74,11 @@ export const PANEL_WINDOW_CONFIGS: Record<string, PanelWindowConfig> = {
     title: "About Peekoo",
     width: 420,
     height: 440,
+  },
+  "panel-updater": {
+    label: "panel-updater",
+    title: "Peekoo Update",
+    width: 760,
+    height: 700,
   },
 };

--- a/apps/desktop-ui/src/views/UpdaterView.tsx
+++ b/apps/desktop-ui/src/views/UpdaterView.tsx
@@ -1,0 +1,141 @@
+import { UpdatePromptDialog } from "@/features/about/UpdatePromptDialog";
+import { checkForAppUpdates, installAppUpdate, type AppUpdateInfo } from "@/lib/updater";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useEffect, useState } from "react";
+
+const FORCE_UPDATER_IN_DEV = import.meta.env.DEV && import.meta.env.VITE_FORCE_UPDATER_DIALOG === "true";
+
+export default function UpdaterView() {
+  const [updateInfo, setUpdateInfo] = useState<AppUpdateInfo | null>(null);
+  const [isInstallingUpdate, setIsInstallingUpdate] = useState(false);
+  const [updateError, setUpdateError] = useState<string | null>(null);
+  const [downloadedBytes, setDownloadedBytes] = useState(0);
+  const [totalBytes, setTotalBytes] = useState<number | null>(null);
+  const [installPhase, setInstallPhase] = useState<"idle" | "downloading" | "installing">("idle");
+  const [downloadStartMs, setDownloadStartMs] = useState<number | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    void checkForAppUpdates({ forceInDev: FORCE_UPDATER_IN_DEV }).then((nextUpdateInfo) => {
+      if (!active) {
+        return;
+      }
+
+      if (!nextUpdateInfo) {
+        void getCurrentWindow().close();
+        return;
+      }
+
+      setUpdateInfo(nextUpdateInfo);
+      setUpdateError(null);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  async function handleInstallUpdate() {
+    if (!updateInfo) {
+      return;
+    }
+
+    if (updateInfo.update === null) {
+      setUpdateError("Dev mock mode: install is disabled.");
+      return;
+    }
+
+    setIsInstallingUpdate(true);
+    setUpdateError(null);
+    setDownloadedBytes(0);
+    setTotalBytes(null);
+    setInstallPhase("downloading");
+
+    try {
+      await installAppUpdate(updateInfo.update, (event) => {
+        switch (event.event) {
+          case "Started": {
+            setInstallPhase("downloading");
+            setDownloadedBytes(0);
+            setTotalBytes(event.data.contentLength ?? null);
+            setDownloadStartMs(Date.now());
+            break;
+          }
+          case "Progress": {
+            setInstallPhase("downloading");
+            setDownloadedBytes((current) => current + event.data.chunkLength);
+            break;
+          }
+          case "Finished": {
+            setInstallPhase("installing");
+            setDownloadStartMs(null);
+            break;
+          }
+        }
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      setUpdateError(message);
+      setIsInstallingUpdate(false);
+      setInstallPhase("idle");
+      setDownloadStartMs(null);
+    }
+  }
+
+  async function closeUpdaterPanel() {
+    if (isInstallingUpdate) {
+      return;
+    }
+
+    await getCurrentWindow().close();
+  }
+
+  const progressPercent = totalBytes && totalBytes > 0
+    ? Math.min(100, Math.round((downloadedBytes / totalBytes) * 100))
+    : null;
+
+  const etaSeconds = (() => {
+    if (!isInstallingUpdate || installPhase !== "downloading") {
+      return null;
+    }
+
+    if (!totalBytes || totalBytes <= 0 || downloadedBytes <= 0 || !downloadStartMs) {
+      return null;
+    }
+
+    const elapsedMs = Date.now() - downloadStartMs;
+    if (elapsedMs < 1000) {
+      return null;
+    }
+
+    const bytesPerSecond = downloadedBytes / (elapsedMs / 1000);
+    if (!Number.isFinite(bytesPerSecond) || bytesPerSecond <= 0) {
+      return null;
+    }
+
+    const remainingBytes = totalBytes - downloadedBytes;
+    if (remainingBytes <= 0) {
+      return 0;
+    }
+
+    return Math.max(0, Math.round(remainingBytes / bytesPerSecond));
+  })();
+
+  return (
+    <div className="h-screen w-screen bg-space-void/90">
+      <UpdatePromptDialog
+        updateInfo={updateInfo}
+        isInstalling={isInstallingUpdate}
+        installError={updateError}
+        installPhase={installPhase}
+        downloadedBytes={downloadedBytes}
+        totalBytes={totalBytes}
+        progressPercent={progressPercent}
+        etaSeconds={etaSeconds}
+        onInstall={() => void handleInstallUpdate()}
+        onLater={() => void closeUpdaterPanel()}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## What changed

- Replaced the native updater `ask(...)` prompt with an in-app updater experience that renders release notes markdown via `Streamdown`
- Added a dedicated `panel-updater` window (`760x700`) so changelogs are readable instead of being constrained by the small main sprite window
- Added install progress UX (phase, progress bar, bytes, ETA) and a `View full changelog` action that opens the release page in the system browser
- Added release-note normalization (strip leading HTML comments, normalize line endings, trim) and dev-only force mode for easier local UI testing
- Updated updater i18n keys across locales and recorded the change in `ai/memories/changelogs/202604111515-fix-updater-markdown-release-notes.md`

## Release notes

- [x] Add at least one release-note label: `feature`, `fix`, `docs`, `test`, `chore`, `ci`, or `refactor`
- [ ] Use `skip-changelog` if this PR should be excluded from generated release notes

## Verification

- [x] Tests pass locally
- [x] `cd apps/desktop-ui && bun test src/lib/release-notes.test.ts src/features/about/about-state.test.ts`
- [x] `cd apps/desktop-ui && bun run build`