### PR TITLE
fix(ci): set TAURI_BUNDLER_DMG_IGNORE_CI for macOS dmg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,7 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_API_HOST: ${{ secrets.POSTHOG_API_HOST }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          TAURI_BUNDLER_DMG_IGNORE_CI: false
           APPIMAGE_EXTRACT_AND_RUN: 1
           NO_STRIP: 1
         with:


### PR DESCRIPTION
## What changed

- Added `TAURI_BUNDLER_DMG_IGNORE_CI: false` to the Tauri release build step environment in `.github/workflows/release.yml`
- This targets intermittent macOS DMG bundling failures (`bundle_dmg.sh`) on GitHub runners

## Release notes

- [x] Add at least one release-note label: `feature`, `fix`, `docs`, `test`, `chore`, `ci`, or `refactor`
- [ ] Use `skip-changelog` if this PR should be excluded from generated release notes

## Verification

- [x] Tests pass locally
- [x] Workflow change only; no runtime code changes