### PR TITLE
fix(about): remove duplicate update imports

### DIFF
--- a/apps/desktop-ui/src/features/about/AboutPanel.tsx
+++ b/apps/desktop-ui/src/features/about/AboutPanel.tsx
@@ -3,8 +3,6 @@ import { Button } from "@/components/ui/button";
 import { InstallProgressCard } from "@/components/update/InstallProgressCard";
 import { ReleaseNotesMarkdown } from "@/components/update/ReleaseNotesMarkdown";
 import { normalizeReleaseNotes } from "@/lib/release-notes";
-import { InstallProgressCard } from "@/components/update/InstallProgressCard";
-import { ReleaseNotesMarkdown } from "@/components/update/ReleaseNotesMarkdown";
 import { invoke } from "@tauri-apps/api/core";
 import { useAboutPanel } from "./useAboutPanel";
 import { useTranslation } from "react-i18next";


### PR DESCRIPTION
## Summary
- remove duplicated `InstallProgressCard` and `ReleaseNotesMarkdown` imports in `AboutPanel`
- resolve TypeScript duplicate identifier build failure in `bun run build`
- keep about panel behavior unchanged while restoring clean frontend build