### PR TITLE
fix(sprite): stabilize Windows rendering and sprite switches

### DIFF
--- a/ai/memories/changelogs/202604130929-fix-windows-sprite-canvas-scaling.md
+++ b/ai/memories/changelogs/202604130929-fix-windows-sprite-canvas-scaling.md
@@ -1,0 +1,24 @@
+## 2026-04-13 09:29: fix: stabilize sprite canvas scaling on Windows
+
+**What changed:**
+- Extracted sprite canvas sizing into `apps/desktop-ui/src/components/sprite/spriteCanvasSize.ts` so logical display size and backing canvas size are computed consistently from frame size, scale, and `devicePixelRatio`.
+- Updated `apps/desktop-ui/src/components/sprite/SpriteAnimation.tsx` to remove the extra `ctx.scale(...)` call and rely on a single `ctx.setTransform(...)` draw path.
+- Added `apps/desktop-ui/src/components/sprite/spriteManifest.ts` and updated `Sprite.tsx` to render only when the fetched manifest matches the current `activeSpriteId`.
+- Updated `Sprite.tsx` to cache fetched manifests, prefetch known sprite manifests, and apply a short fade-in when the active sprite changes.
+- Added `apps/desktop-ui/tests/sprite-canvas-size.test.ts` to lock in the intended DPR behavior for integer and fractional Windows scale factors.
+- Added `apps/desktop-ui/tests/sprite-manifest.test.ts` to prevent rendering a stale manifest while the next sprite's manifest is still loading.
+- Added explicit sprite image load error logging in `SpriteAnimation.tsx`.
+
+**Why:**
+- The cute dog sprite rendered incorrectly in the main transparent Tauri window on Windows while still loading correctly in the settings preview.
+- The renderer was applying high-DPI scaling in two different places, which made Windows/WebView2 a likely source of inconsistent sprite sizing and placement.
+- Switching from dog to cat briefly rendered the cat using the dog's manifest scale before the cat manifest fetch completed, causing a visible oversized flash.
+- Even after fixing the stale-manifest flash, uncached sprite switches could briefly render blank while the next manifest loaded, so caching and prefetching smooths the transition.
+
+**Files affected:**
+- `apps/desktop-ui/src/components/sprite/SpriteAnimation.tsx`
+- `apps/desktop-ui/src/components/sprite/spriteCanvasSize.ts`
+- `apps/desktop-ui/src/components/sprite/spriteManifest.ts`
+- `apps/desktop-ui/src/components/sprite/Sprite.tsx`
+- `apps/desktop-ui/tests/sprite-canvas-size.test.ts`
+- `apps/desktop-ui/tests/sprite-manifest.test.ts`

--- a/apps/desktop-ui/src/components/sprite/Sprite.tsx
+++ b/apps/desktop-ui/src/components/sprite/Sprite.tsx
@@ -1,7 +1,9 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import SpriteAnimation from "./SpriteAnimation";
+import { getActiveSpriteManifest } from "./spriteManifest";
+import type { SpriteInfo } from "@/types/global-settings";
 import type { AnimationType, SpriteState, SpriteManifest } from "@/types/sprite";
 
 // Map mood states to sprite animation types (new sprite sheet layout)
@@ -34,6 +36,7 @@ const ANIMATION_TO_TYPE: Record<string, AnimationType> = {
 };
 
 const DEFAULT_SPRITE_ID = "dark-cat";
+const SPRITE_SWITCH_FADE_MS = 150;
 
 interface SpriteProps {
   state?: SpriteState;
@@ -48,7 +51,8 @@ export function Sprite({ state, animationOverride = null }: SpriteProps) {
   };
 
   const [activeSpriteId, setActiveSpriteId] = useState(DEFAULT_SPRITE_ID);
-  const [manifest, setManifest] = useState<SpriteManifest | null>(null);
+  const [manifests, setManifests] = useState<Record<string, SpriteManifest>>({});
+  const [spriteVisible, setSpriteVisible] = useState(true);
 
   // Load active sprite ID from global settings on mount
   useEffect(() => {
@@ -73,11 +77,70 @@ export function Sprite({ state, animationOverride = null }: SpriteProps) {
 
   // Load sprite manifest
   useEffect(() => {
-    fetch(`/sprites/${activeSpriteId}/manifest.json`)
-      .then((res) => res.json())
-      .then((data: SpriteManifest) => setManifest(data))
-      .catch((err) => console.error("Failed to load sprite manifest", err));
+    let cancelled = false;
+
+    const loadManifest = async (spriteId: string) => {
+      try {
+        const response = await fetch(`/sprites/${spriteId}/manifest.json`);
+        const data = (await response.json()) as SpriteManifest;
+        if (cancelled) {
+          return;
+        }
+        setManifests((prev) => {
+          if (prev[spriteId] === data) {
+            return prev;
+          }
+          return {
+            ...prev,
+            [spriteId]: data,
+          };
+        });
+      } catch (err) {
+        console.error("Failed to load sprite manifest", err);
+      }
+    };
+
+    void loadManifest(activeSpriteId);
+
+    invoke<SpriteInfo[]>("app_settings_list_sprites")
+      .then((sprites) => {
+        sprites
+          .filter((sprite) => sprite.id !== activeSpriteId)
+          .forEach((sprite) => {
+            void loadManifest(sprite.id);
+          });
+      })
+      .catch((err) => console.error("Failed to prefetch sprite manifests", err));
+
+    return () => {
+      cancelled = true;
+    };
   }, [activeSpriteId]);
+
+  const activeManifest = getActiveSpriteManifest(manifests, activeSpriteId);
+
+  useEffect(() => {
+    if (!activeManifest) {
+      return;
+    }
+
+    setSpriteVisible(false);
+    const timeoutId = window.setTimeout(() => {
+      setSpriteVisible(true);
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [activeSpriteId, activeManifest]);
+
+  const spriteClasses = useMemo(
+    () =>
+      spriteVisible
+        ? "opacity-100"
+        : "opacity-0",
+    [spriteVisible],
+  );
 
   // Determine animation type from mood or animation state
   const getAnimationType = (): AnimationType => {
@@ -98,21 +161,25 @@ export function Sprite({ state, animationOverride = null }: SpriteProps) {
     return "idle";
   };
 
-  if (!manifest) {
+  if (!activeManifest) {
     return null;
   }
 
   return (
-    <div className="flex items-center justify-center">
+    <div
+      className={`flex items-center justify-center transition-opacity ease-out ${spriteClasses}`}
+      style={{ transitionDuration: `${SPRITE_SWITCH_FADE_MS}ms` }}
+    >
       <SpriteAnimation
+        key={activeSpriteId}
         animation={getAnimationType()}
-        frameRate={manifest.frameRate || 8}
-        scale={manifest.scale ?? 0.40}
-        chromaKey={manifest.chromaKey}
-        imageSrc={`/sprites/${activeSpriteId}/${manifest.image}`}
-        columns={manifest.layout.columns}
-        rows={manifest.layout.rows}
-        pixelArt={manifest.chromaKey.pixelArt}
+        frameRate={activeManifest.frameRate || 8}
+        scale={activeManifest.scale ?? 0.40}
+        chromaKey={activeManifest.chromaKey}
+        imageSrc={`/sprites/${activeSpriteId}/${activeManifest.image}`}
+        columns={activeManifest.layout.columns}
+        rows={activeManifest.layout.rows}
+        pixelArt={activeManifest.chromaKey.pixelArt}
         onFrameChange={() => {
           // Optional: Log frame changes for debugging
         }}

--- a/apps/desktop-ui/src/components/sprite/SpriteAnimation.tsx
+++ b/apps/desktop-ui/src/components/sprite/SpriteAnimation.tsx
@@ -11,6 +11,7 @@ import {
   validateAtlas,
   type SpriteAtlasGrid,
 } from "./spriteAtlas";
+import { getSpriteCanvasSize } from "./spriteCanvasSize";
 
 interface SpriteAnimationProps {
   animation?: AnimationType;
@@ -85,24 +86,21 @@ export default function SpriteAnimation({
         chromaKey === false ? img : buildKeyedSpriteSheet(img, chromaKey);
 
       if (canvasRef.current) {
-        // Use window.devicePixelRatio for crisp rendering on high-DPI displays
-        const dpr = window.devicePixelRatio || 1;
-        const displayWidth = Math.max(1, Math.round(atlas.nominalFrameWidth * scale));
-        const displayHeight = Math.max(1, Math.round(atlas.nominalFrameHeight * scale));
+        const canvasSize = getSpriteCanvasSize({
+          nominalFrameWidth: atlas.nominalFrameWidth,
+          nominalFrameHeight: atlas.nominalFrameHeight,
+          scale,
+          devicePixelRatio: window.devicePixelRatio || 1,
+        });
 
-        canvasRef.current.width = displayWidth * dpr;
-        canvasRef.current.height = displayHeight * dpr;
-        
-        // Scale context to match dpr
-        const ctx = canvasRef.current.getContext("2d");
-        if (ctx) {
-           ctx.scale(dpr, dpr);
-        }
-        
-        // Set CSS size
-        canvasRef.current.style.width = `${displayWidth}px`;
-        canvasRef.current.style.height = `${displayHeight}px`;
+        canvasRef.current.width = canvasSize.canvasWidth;
+        canvasRef.current.height = canvasSize.canvasHeight;
+        canvasRef.current.style.width = `${canvasSize.displayWidth}px`;
+        canvasRef.current.style.height = `${canvasSize.displayHeight}px`;
       }
+    };
+    img.onerror = () => {
+      console.error("Failed to load sprite image", imageSrc);
     };
   }, [scale, chromaKey, imageSrc, columns, rows]);
 

--- a/apps/desktop-ui/src/components/sprite/spriteCanvasSize.ts
+++ b/apps/desktop-ui/src/components/sprite/spriteCanvasSize.ts
@@ -1,0 +1,35 @@
+interface SpriteCanvasSizeInput {
+  nominalFrameWidth: number;
+  nominalFrameHeight: number;
+  scale: number;
+  devicePixelRatio: number;
+}
+
+interface SpriteCanvasSize {
+  displayWidth: number;
+  displayHeight: number;
+  canvasWidth: number;
+  canvasHeight: number;
+  devicePixelRatio: number;
+}
+
+export function getSpriteCanvasSize({
+  nominalFrameWidth,
+  nominalFrameHeight,
+  scale,
+  devicePixelRatio,
+}: SpriteCanvasSizeInput): SpriteCanvasSize {
+  const normalizedDpr = Number.isFinite(devicePixelRatio) && devicePixelRatio > 0
+    ? devicePixelRatio
+    : 1;
+  const displayWidth = Math.max(1, Math.round(nominalFrameWidth * scale));
+  const displayHeight = Math.max(1, Math.round(nominalFrameHeight * scale));
+
+  return {
+    displayWidth,
+    displayHeight,
+    canvasWidth: Math.max(1, Math.round(displayWidth * normalizedDpr)),
+    canvasHeight: Math.max(1, Math.round(displayHeight * normalizedDpr)),
+    devicePixelRatio: normalizedDpr,
+  };
+}

--- a/apps/desktop-ui/src/components/sprite/spriteManifest.ts
+++ b/apps/desktop-ui/src/components/sprite/spriteManifest.ts
@@ -1,0 +1,8 @@
+import type { SpriteManifest } from "@/types/sprite";
+
+export function getActiveSpriteManifest(
+  manifests: Record<string, SpriteManifest>,
+  activeSpriteId: string,
+): SpriteManifest | null {
+  return manifests[activeSpriteId] ?? null;
+}

--- a/apps/desktop-ui/tests/sprite-canvas-size.test.ts
+++ b/apps/desktop-ui/tests/sprite-canvas-size.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { getSpriteCanvasSize } from "../src/components/sprite/spriteCanvasSize";
+
+describe("getSpriteCanvasSize", () => {
+  test("returns matching logical and backing sizes at dpr 1", () => {
+    expect(getSpriteCanvasSize({
+      nominalFrameWidth: 276,
+      nominalFrameHeight: 274,
+      scale: 0.4,
+      devicePixelRatio: 1,
+    })).toEqual({
+      displayWidth: 110,
+      displayHeight: 110,
+      canvasWidth: 110,
+      canvasHeight: 110,
+      devicePixelRatio: 1,
+    });
+  });
+
+  test("keeps logical size stable while scaling backing canvas for fractional dpr", () => {
+    expect(getSpriteCanvasSize({
+      nominalFrameWidth: 276,
+      nominalFrameHeight: 274,
+      scale: 0.4,
+      devicePixelRatio: 1.25,
+    })).toEqual({
+      displayWidth: 110,
+      displayHeight: 110,
+      canvasWidth: 138,
+      canvasHeight: 138,
+      devicePixelRatio: 1.25,
+    });
+  });
+
+  test("clamps very small scaled sprites to at least one pixel", () => {
+    expect(getSpriteCanvasSize({
+      nominalFrameWidth: 10,
+      nominalFrameHeight: 8,
+      scale: 0.01,
+      devicePixelRatio: 1.5,
+    })).toEqual({
+      displayWidth: 1,
+      displayHeight: 1,
+      canvasWidth: 2,
+      canvasHeight: 2,
+      devicePixelRatio: 1.5,
+    });
+  });
+});

--- a/apps/desktop-ui/tests/sprite-manifest.test.ts
+++ b/apps/desktop-ui/tests/sprite-manifest.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { getActiveSpriteManifest } from "../src/components/sprite/spriteManifest";
+import type { SpriteManifest } from "../src/types/sprite";
+
+const cuteDogManifest: SpriteManifest = {
+  id: "cute-dog",
+  name: "Cute Dog",
+  description: "Dog",
+  image: "sprite.png",
+  layout: { columns: 8, rows: 7 },
+  scale: 0.4,
+  frameRate: 6,
+  chromaKey: {
+    targetColor: [255, 0, 255],
+    minRbOverG: 32,
+    threshold: 100,
+    softness: 80,
+    spillSuppression: {
+      enabled: true,
+      threshold: 260,
+      strength: 0.9,
+    },
+    pixelArt: false,
+  },
+};
+
+describe("getActiveSpriteManifest", () => {
+  test("returns the manifest when it matches the active sprite", () => {
+    expect(
+      getActiveSpriteManifest({ "cute-dog": cuteDogManifest }, "cute-dog"),
+    ).toBe(cuteDogManifest);
+  });
+
+  test("returns null while the next sprite manifest is still loading", () => {
+    expect(
+      getActiveSpriteManifest({ "cute-dog": cuteDogManifest }, "dark-cat"),
+    ).toBeNull();
+  });
+
+  test("returns the cached manifest for a previously loaded sprite", () => {
+    const darkCatManifest: SpriteManifest = {
+      ...cuteDogManifest,
+      id: "dark-cat",
+      name: "Dark Cat",
+      scale: 0.15,
+    };
+
+    expect(
+      getActiveSpriteManifest(
+        {
+          "cute-dog": cuteDogManifest,
+          "dark-cat": darkCatManifest,
+        },
+        "dark-cat",
+      ),
+    ).toBe(darkCatManifest);
+  });
+});


### PR DESCRIPTION
## What changed

- fix the sprite canvas DPI sizing path so Windows uses consistent logical and backing canvas dimensions
- remove the transient stale-manifest render that briefly showed the cat at the dog's larger scale
- cache and prefetch sprite manifests so switching between sprites no longer blanks while the next manifest loads
- add focused tests for canvas sizing and active-manifest resolution
- record the change in the AI changelog memory

## Release notes

- [x] Add at least one release-note label: `feature`, `fix`, `docs`, `test`, `chore`, `ci`, or `refactor`
- [ ] Use `skip-changelog` if this PR should be excluded from generated release notes

## Verification

- [x] Tests pass locally

Commands run:
- `bun test tests/sprite-manifest.test.ts tests/sprite-canvas-size.test.ts tests/sprite-bubble.test.ts tests/sprite-action-menu-layout.test.ts tests/sprite-action-menu-popup-position.test.ts`
- `bun run build`