### PR TITLE
feat(about): add GitHub link and star request to about page

### DIFF
--- a/apps/desktop-ui/src/features/about/AboutPanel.tsx
+++ b/apps/desktop-ui/src/features/about/AboutPanel.tsx
@@ -6,6 +6,7 @@ import { normalizeReleaseNotes } from "@/lib/release-notes";
 import { invoke } from "@tauri-apps/api/core";
 import { useAboutPanel } from "./useAboutPanel";
 import { useTranslation } from "react-i18next";
+import { Github, Star } from "lucide-react";
 
 function formatReleaseDate(value: string | null): string | null {
   if (!value) {
@@ -87,6 +88,22 @@ export function AboutPanel() {
             {snapshot.isUpdateAvailable ? t("about.updateAvailable") : t("about.upToDate")}
           </Badge>
         </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-3 rounded-xl border border-glass-border/70 bg-space-overlay/40 px-3 py-3">
+        <div className="flex items-center gap-2">
+          <Star className="h-4 w-4 text-warning" />
+          <span className="text-sm text-text-primary">{t("about.starRequest")}</span>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-2"
+          onClick={() => void invoke("system_open_url", { url: "https://github.com/feed-mob/peekoo-ai" })}
+        >
+          <Github className="h-4 w-4" />
+          <span>{t("about.openGitHub")}</span>
+        </Button>
       </div>
 
       <div className="space-y-3">

--- a/apps/desktop-ui/src/locales/en.json
+++ b/apps/desktop-ui/src/locales/en.json
@@ -246,7 +246,9 @@
     "installing": "Installing...",
     "installAndRestart": "Install and Restart",
     "openLogs": "Open Logs",
-    "unknownError": "Unknown error"
+    "unknownError": "Unknown error",
+    "starRequest": "Enjoying Peekoo? Give us a star on GitHub!",
+    "openGitHub": "GitHub"
   },
   "plugins": {
     "tabs": {

--- a/apps/desktop-ui/src/locales/es.json
+++ b/apps/desktop-ui/src/locales/es.json
@@ -246,7 +246,9 @@
     "installing": "Instalando...",
     "installAndRestart": "Instalar y reiniciar",
     "openLogs": "Abrir registros",
-    "unknownError": "Error desconocido"
+    "unknownError": "Error desconocido",
+    "starRequest": "¿Disfrutando Peekoo? ¡Danos una estrella en GitHub!",
+    "openGitHub": "GitHub"
   },
   "plugins": {
     "tabs": {

--- a/apps/desktop-ui/src/locales/fr.json
+++ b/apps/desktop-ui/src/locales/fr.json
@@ -256,7 +256,9 @@
     "installing": "Installation...",
     "installAndRestart": "Installer et redémarrer",
     "openLogs": "Ouvrir les journaux",
-    "unknownError": "Erreur inconnue"
+    "unknownError": "Erreur inconnue",
+    "starRequest": "Vous appréciez Peekoo ? Donnez-nous une étoile sur GitHub !",
+    "openGitHub": "GitHub"
   },
   "plugins": {
     "tabs": {

--- a/apps/desktop-ui/src/locales/ja.json
+++ b/apps/desktop-ui/src/locales/ja.json
@@ -246,7 +246,9 @@
     "installing": "インストール中...",
     "installAndRestart": "インストールして再起動",
     "openLogs": "ログを開く",
-    "unknownError": "不明なエラー"
+    "unknownError": "不明なエラー",
+    "starRequest": "Peekoo を気に入りましたか？GitHub でスターを付けてください！",
+    "openGitHub": "GitHub"
   },
   "plugins": {
     "tabs": {

--- a/apps/desktop-ui/src/locales/zh-TW.json
+++ b/apps/desktop-ui/src/locales/zh-TW.json
@@ -246,7 +246,9 @@
     "installing": "安裝中...",
     "installAndRestart": "安裝並重新啟動",
     "openLogs": "開啟日誌",
-    "unknownError": "未知錯誤"
+    "unknownError": "未知錯誤",
+    "starRequest": "喜歡 Peekoo？在 GitHub 上給我們一顆星吧！",
+    "openGitHub": "GitHub"
   },
   "plugins": {
     "tabs": {

--- a/apps/desktop-ui/src/locales/zh.json
+++ b/apps/desktop-ui/src/locales/zh.json
@@ -246,7 +246,9 @@
     "installing": "安装中...",
     "installAndRestart": "安装并重启",
     "openLogs": "打开日志",
-    "unknownError": "未知错误"
+    "unknownError": "未知错误",
+    "starRequest": "喜欢 Peekoo？在 GitHub 上给我们一颗星吧！",
+    "openGitHub": "GitHub"
   },
   "plugins": {
     "tabs": {


### PR DESCRIPTION
## Summary

Adds a GitHub star request section to the About page to encourage users to star the project.

### Changes
- Added a new section under the header card with:
  - Star icon (warning color) with friendly message
  - GitHub button that opens the repository in system browser
- Styled consistently with existing glassmorphism design
- Added translations for all supported languages (EN, ZH, ZH-TW, JA, ES, FR)

### Placement
The star request appears right under the app header card, making it visible early without interrupting the version information flow.

### Screenshot
The section displays:
- Star icon + "Enjoying Peekoo? Give us a star on GitHub!" message
- GitHub button linking to https://github.com/feed-mob/peekoo-ai