### PR TITLE
fix(auth): avoid repeated Windows terminal popups during ACP login checks

### DIFF
--- a/ai/memories/changelogs/202604211200-fix-windows-acp-login-terminal-spam.md
+++ b/ai/memories/changelogs/202604211200-fix-windows-acp-login-terminal-spam.md
@@ -1,0 +1,14 @@
+## 2026-04-21 12:00: fix: Windows ACP login terminal spam
+
+**What changed:**
+- Added a Windows-only background spawn configuration in ACP backend process startup so ACP inspection/auth helper processes do not open visible console windows.
+- Removed automatic post-login polling in runtime configuration dialog that repeatedly refreshed capabilities every 5 seconds.
+- Added a short terminal-launch cooldown in the dialog to prevent rapid repeated login launches from repeated clicks.
+
+**Why:**
+- Kimi/Qwen login on Windows could trigger multiple terminal windows due to repeated background ACP inspections and auth status checks.
+- The login flow should open only the user-triggered terminal, while background ACP checks remain invisible.
+
+**Files affected:**
+- `crates/peekoo-agent/src/backend/acp.rs`
+- `apps/desktop-ui/src/features/agent-runtimes/ConfigureProviderDialog.tsx`

--- a/apps/desktop-ui/src/features/agent-runtimes/ConfigureProviderDialog.tsx
+++ b/apps/desktop-ui/src/features/agent-runtimes/ConfigureProviderDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import {
@@ -92,8 +92,29 @@ export function ConfigureProviderDialog({
   const [inspection, setInspection] = useState<RuntimeInspectionResult | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [showAuthMethods, setShowAuthMethods] = useState(false);
+  const [isTerminalLaunchCoolingDown, setIsTerminalLaunchCoolingDown] = useState(false);
   const [selectedModel, setSelectedModel] = useState<string>("");
   const [copiedMethodId, setCopiedMethodId] = useState<string | null>(null);
+  const terminalLaunchCooldownRef = useRef<number | null>(null);
+
+  const startTerminalLaunchCooldown = () => {
+    setIsTerminalLaunchCoolingDown(true);
+    if (terminalLaunchCooldownRef.current !== null) {
+      window.clearTimeout(terminalLaunchCooldownRef.current);
+    }
+    terminalLaunchCooldownRef.current = window.setTimeout(() => {
+      setIsTerminalLaunchCoolingDown(false);
+      terminalLaunchCooldownRef.current = null;
+    }, 8000);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (terminalLaunchCooldownRef.current !== null) {
+        window.clearTimeout(terminalLaunchCooldownRef.current);
+      }
+    };
+  }, []);
 
   // Load config and inspect runtime when dialog opens
   useEffect(() => {
@@ -109,6 +130,7 @@ export function ConfigureProviderDialog({
       setSelectedModel(provider.config.defaultModel || "");
       setShowAdvanced(false);
       setShowAuthMethods(false);
+      setIsTerminalLaunchCoolingDown(false);
 
       if (provider.isBundled) {
         return;
@@ -208,10 +230,8 @@ export function ConfigureProviderDialog({
       if (result.status === "authenticated") {
         await handleRefreshCapabilities();
       } else {
-        // Terminal login started — poll for auth completion so the user
-        // doesn't have to manually click Refresh after finishing in the terminal.
         setShowAuthMethods(true);
-        pollForAuthCompletion(provider.providerId);
+        startTerminalLaunchCooldown();
       }
     } catch (err) {
       setError(String(err));
@@ -232,33 +252,12 @@ export function ConfigureProviderDialog({
         success: true,
         message: result.message,
       });
-      pollForAuthCompletion(provider.providerId);
+      startTerminalLaunchCooldown();
     } catch (err) {
       setError(String(err));
     } finally {
       setIsAuthenticating(false);
     }
-  };
-
-  const pollForAuthCompletion = (providerId: string) => {
-    let attempts = 0;
-    const maxAttempts = 24; // ~2 minutes at 5s intervals
-    const interval = setInterval(async () => {
-      attempts++;
-      try {
-        const result = await onRefreshCapabilities(providerId);
-        if (!result.authRequired) {
-          clearInterval(interval);
-          setShowAuthMethods(false);
-          setTestResult({ success: true, message: "Login successful." });
-        }
-      } catch {
-        // ignore transient errors during polling
-      }
-      if (attempts >= maxAttempts) {
-        clearInterval(interval);
-      }
-    }, 5000);
   };
 
   const handleModelChange = (modelId: string) => {
@@ -432,7 +431,7 @@ export function ConfigureProviderDialog({
                       size="sm"
                       variant="default"
                       onClick={() => void handleNativeLogin()}
-                      disabled={isAuthenticating}
+                      disabled={isAuthenticating || isTerminalLaunchCoolingDown}
                     >
                       {isAuthenticating ? (
                         <Loader2 className="mr-2 h-3 w-3 animate-spin" />
@@ -457,6 +456,9 @@ export function ConfigureProviderDialog({
                       )}
                     </Button>
                   </div>
+                  <p className="text-xs text-text-muted">
+                    {t("agentRuntimes.configureDialog.manualRefreshAfterLoginHint")}
+                  </p>
                 </div>
               )}
 
@@ -475,7 +477,7 @@ export function ConfigureProviderDialog({
                           size="sm"
                           variant="outline"
                           onClick={() => handleAuthenticate(method.id)}
-                          disabled={isAuthenticating}
+                          disabled={isAuthenticating || isTerminalLaunchCoolingDown}
                         >
                           {isAuthenticating ? (
                             <Loader2 className="mr-2 h-3 w-3 animate-spin" />

--- a/apps/desktop-ui/src/locales/en.json
+++ b/apps/desktop-ui/src/locales/en.json
@@ -533,6 +533,7 @@
       "hideAdvancedLoginOptions": "Hide advanced login options",
       "nativeLoginTitle": "Native CLI Login",
       "nativeLoginDescription": "Open a terminal and run the runtime's built-in login command.",
+      "manualRefreshAfterLoginHint": "After finishing login in the terminal, click Refresh Status.",
       "openTerminalToLogin": "Open Terminal to Login",
       "refreshStatus": "Refresh Status",
       "modelSection": "Model",

--- a/crates/peekoo-agent/src/backend/acp.rs
+++ b/crates/peekoo-agent/src/backend/acp.rs
@@ -19,6 +19,17 @@ use tokio::process::Command;
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
+#[cfg(target_os = "windows")]
+fn configure_background_spawn(cmd: &mut Command) {
+    use std::os::windows::process::CommandExt;
+
+    // CREATE_NO_WINDOW
+    cmd.creation_flags(0x0800_0000);
+}
+
+#[cfg(not(target_os = "windows"))]
+fn configure_background_spawn(_cmd: &mut Command) {}
+
 /// ACP-based backend implementation that wraps non-Send ACP operations
 pub struct AcpBackend {
     /// Command to spawn the ACP agent
@@ -525,6 +536,7 @@ impl AcpBackend {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit());
+        configure_background_spawn(&mut cmd);
 
         // Set environment variables
         for (key, value) in &self.environment {


### PR DESCRIPTION
## Summary
- prevent Windows ACP background inspection/auth processes from opening visible console windows by setting hidden spawn flags in the ACP backend
- stop repeated post-login auto polling in runtime configuration and require explicit refresh after terminal login
- add a clear UI hint in the native login card telling users to click Refresh Status after finishing terminal login

## Validation
- rtk cargo test -p peekoo-agent
- rtk cargo test -p peekoo-agent-app
- bun run build (apps/desktop-ui)