### PR TITLE
fix(auth): clear stale terminal login success feedback

### DIFF
--- a/apps/desktop-ui/src/features/agent-runtimes/ConfigureProviderDialog.tsx
+++ b/apps/desktop-ui/src/features/agent-runtimes/ConfigureProviderDialog.tsx
@@ -42,6 +42,10 @@ import {
   type RuntimeAuthenticationResult,
 } from "@/types/agent-runtime";
 import { getProviderAuthState, getProviderLoginPresentation } from "./provider-auth-state";
+import {
+  getAuthFeedbackAfterRefresh,
+  getAuthFeedbackAfterRuntimeAuthentication,
+} from "./runtime-auth-feedback";
 
 interface ConfigureProviderDialogProps {
   provider: RuntimeInfo | null;
@@ -93,6 +97,7 @@ export function ConfigureProviderDialog({
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [showAuthMethods, setShowAuthMethods] = useState(false);
   const [isTerminalLaunchCoolingDown, setIsTerminalLaunchCoolingDown] = useState(false);
+  const [awaitingManualLoginRefresh, setAwaitingManualLoginRefresh] = useState(false);
   const [selectedModel, setSelectedModel] = useState<string>("");
   const [copiedMethodId, setCopiedMethodId] = useState<string | null>(null);
   const terminalLaunchCooldownRef = useRef<number | null>(null);
@@ -131,6 +136,7 @@ export function ConfigureProviderDialog({
       setShowAdvanced(false);
       setShowAuthMethods(false);
       setIsTerminalLaunchCoolingDown(false);
+      setAwaitingManualLoginRefresh(false);
 
       if (provider.isBundled) {
         return;
@@ -196,6 +202,18 @@ export function ConfigureProviderDialog({
     try {
       const result = await onRefreshCapabilities(provider.providerId);
       setInspection(result);
+      const feedback = getAuthFeedbackAfterRefresh(
+        awaitingManualLoginRefresh,
+        result.authRequired,
+        t("agentRuntimes.configureDialog.loginCompletedMessage"),
+      );
+      setAwaitingManualLoginRefresh(feedback.awaitingManualRefresh);
+      if (awaitingManualLoginRefresh) {
+        setTestResult(feedback.alert);
+      }
+      if (feedback.alert) {
+        setShowAuthMethods(false);
+      }
       const loginPresentation = getProviderLoginPresentation(result);
       setShowAuthMethods((current) =>
         loginPresentation.primaryLoginMethod === "acp" ? result.authRequired || current : current,
@@ -223,10 +241,9 @@ export function ConfigureProviderDialog({
     setTestResult(null);
     try {
       const result = await onAuthenticate(provider.providerId, methodId);
-      setTestResult({
-        success: true,
-        message: result.message,
-      });
+      const feedback = getAuthFeedbackAfterRuntimeAuthentication(result);
+      setAwaitingManualLoginRefresh(feedback.awaitingManualRefresh);
+      setTestResult(feedback.alert);
       if (result.status === "authenticated") {
         await handleRefreshCapabilities();
       } else {
@@ -248,10 +265,9 @@ export function ConfigureProviderDialog({
     setTestResult(null);
     try {
       const result = await onNativeLogin(provider.providerId);
-      setTestResult({
-        success: true,
-        message: result.message,
-      });
+      const feedback = getAuthFeedbackAfterRuntimeAuthentication(result);
+      setAwaitingManualLoginRefresh(feedback.awaitingManualRefresh);
+      setTestResult(feedback.alert);
       startTerminalLaunchCooldown();
     } catch (err) {
       setError(String(err));

--- a/apps/desktop-ui/src/features/agent-runtimes/runtime-auth-feedback.test.ts
+++ b/apps/desktop-ui/src/features/agent-runtimes/runtime-auth-feedback.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getAuthFeedbackAfterRefresh,
+  getAuthFeedbackAfterRuntimeAuthentication,
+} from "./runtime-auth-feedback";
+
+describe("getAuthFeedbackAfterRuntimeAuthentication", () => {
+  test("does not report terminal login started as a success alert", () => {
+    expect(
+      getAuthFeedbackAfterRuntimeAuthentication({
+        status: "terminal_login_started",
+        message: "Terminal login started.",
+      }),
+    ).toEqual({
+      awaitingManualRefresh: true,
+      alert: null,
+    });
+  });
+
+  test("keeps immediate authenticated results as success alerts", () => {
+    expect(
+      getAuthFeedbackAfterRuntimeAuthentication({
+        status: "authenticated",
+        message: "Authenticated.",
+      }),
+    ).toEqual({
+      awaitingManualRefresh: false,
+      alert: {
+        success: true,
+        message: "Authenticated.",
+      },
+    });
+  });
+});
+
+describe("getAuthFeedbackAfterRefresh", () => {
+  test("keeps waiting without a stale success alert when login is still required", () => {
+    expect(getAuthFeedbackAfterRefresh(true, true, "Login successful.")).toEqual({
+      awaitingManualRefresh: true,
+      alert: null,
+    });
+  });
+
+  test("reports success after manual refresh confirms login completed", () => {
+    expect(getAuthFeedbackAfterRefresh(true, false, "Login successful.")).toEqual({
+      awaitingManualRefresh: false,
+      alert: {
+        success: true,
+        message: "Login successful.",
+      },
+    });
+  });
+
+  test("leaves unrelated refreshes unchanged", () => {
+    expect(getAuthFeedbackAfterRefresh(false, false, "Login successful.")).toEqual({
+      awaitingManualRefresh: false,
+      alert: null,
+    });
+  });
+});

--- a/apps/desktop-ui/src/features/agent-runtimes/runtime-auth-feedback.ts
+++ b/apps/desktop-ui/src/features/agent-runtimes/runtime-auth-feedback.ts
@@ -1,0 +1,58 @@
+import type { RuntimeAuthenticationResult } from "@/types/agent-runtime";
+
+export interface RuntimeAuthFeedbackAlert {
+  success: boolean;
+  message: string;
+}
+
+export interface RuntimeAuthFeedbackState {
+  awaitingManualRefresh: boolean;
+  alert: RuntimeAuthFeedbackAlert | null;
+}
+
+export function getAuthFeedbackAfterRuntimeAuthentication(
+  result: RuntimeAuthenticationResult,
+): RuntimeAuthFeedbackState {
+  if (result.status === "authenticated") {
+    return {
+      awaitingManualRefresh: false,
+      alert: {
+        success: true,
+        message: result.message,
+      },
+    };
+  }
+
+  return {
+    awaitingManualRefresh: true,
+    alert: null,
+  };
+}
+
+export function getAuthFeedbackAfterRefresh(
+  awaitingManualRefresh: boolean,
+  authRequired: boolean,
+  completedMessage: string,
+): RuntimeAuthFeedbackState {
+  if (!awaitingManualRefresh) {
+    return {
+      awaitingManualRefresh: false,
+      alert: null,
+    };
+  }
+
+  if (authRequired) {
+    return {
+      awaitingManualRefresh: true,
+      alert: null,
+    };
+  }
+
+  return {
+    awaitingManualRefresh: false,
+    alert: {
+      success: true,
+      message: completedMessage,
+    },
+  };
+}

--- a/apps/desktop-ui/src/locales/en.json
+++ b/apps/desktop-ui/src/locales/en.json
@@ -533,6 +533,7 @@
       "hideAdvancedLoginOptions": "Hide advanced login options",
       "nativeLoginTitle": "Native CLI Login",
       "nativeLoginDescription": "Open a terminal and run the runtime's built-in login command.",
+      "loginCompletedMessage": "Login successful.",
       "manualRefreshAfterLoginHint": "After finishing login in the terminal, click Refresh Status.",
       "openTerminalToLogin": "Open Terminal to Login",
       "refreshStatus": "Refresh Status",


### PR DESCRIPTION
## Summary
- stop treating `terminal_login_started` as a successful authentication result in the runtime configuration dialog
- clear stale success alerts until a manual `Refresh Status` confirms that login actually completed
- add focused unit coverage for the manual-refresh auth feedback state transitions

## Validation
- bun test src/features/agent-runtimes/runtime-auth-feedback.test.ts
- bun run build (apps/desktop-ui)