### PR TITLE
style(app-settings): apply cargo fmt fixes

### DIFF
--- a/crates/peekoo-app-settings/build.rs
+++ b/crates/peekoo-app-settings/build.rs
@@ -67,11 +67,13 @@ fn discover_builtin_sprites(sprites_dir: &Path) -> Vec<BuiltinSprite> {
         });
     }
 
-    builtins.sort_by(|left, right| match (left.id == "dark-cat", right.id == "dark-cat") {
-        (true, false) => Ordering::Less,
-        (false, true) => Ordering::Greater,
-        _ => left.id.cmp(&right.id),
-    });
+    builtins.sort_by(
+        |left, right| match (left.id == "dark-cat", right.id == "dark-cat") {
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
+            _ => left.id.cmp(&right.id),
+        },
+    );
 
     builtins
 }

--- a/crates/peekoo-app-settings/src/service.rs
+++ b/crates/peekoo-app-settings/src/service.rs
@@ -795,7 +795,11 @@ mod tests {
     fn list_sprites_returns_builtins() {
         let (svc, _) = test_service();
         let sprites = svc.list_sprites();
-        assert!(sprites.iter().all(|sprite| sprite.source == SpriteSource::Builtin));
+        assert!(
+            sprites
+                .iter()
+                .all(|sprite| sprite.source == SpriteSource::Builtin)
+        );
         assert!(sprites.iter().any(|sprite| sprite.id == "dark-cat"));
         assert!(sprites.iter().any(|sprite| sprite.id == "cute-dog"));
     }


### PR DESCRIPTION
## What changed

- Applied `cargo fmt` fixes to `crates/peekoo-app-settings/build.rs` and `crates/peekoo-app-settings/src/service.rs`

## Release notes

- [x] Add at least one release-note label: `feature`, `fix`, `docs`, `test`, `chore`, `ci`, or `refactor`
- [x] Use `skip-changelog` if this PR should be excluded from generated release notes

## Verification

- [x] Tests pass locally