### PR TITLE
fix(pomodoro): pause timer on app exit to prevent auto-completion on restart

### DIFF
--- a/ai/memories/changelogs/202604221600-fix-pomodoro-timer-on-app-exit.md
+++ b/ai/memories/changelogs/202604221600-fix-pomodoro-timer-on-app-exit.md
@@ -1,0 +1,43 @@
+---
+title: "fix: pause pomodoro timer on app exit to prevent auto-completion on restart"
+date: 2026-04-22
+author: opencode
+tags: [fix, pomodoro, timer, app-lifecycle, tauri]
+---
+
+## Summary
+
+When the user quits the app via the tray menu, the pomodoro timer now pauses instead of continuing to run in the background. This prevents the timer from auto-completing while the app is closed and the memo window from popping up on the next app launch.
+
+## Problem
+
+- The pomodoro timer state is persisted in SQLite and survives app restarts
+- On app startup, `reconcile_runtime_state()` checks if a running timer expired while the app was closed
+- If the timer had expired, it auto-completes the session, inserts a history record, and potentially auto-advances to the next session
+- The frontend's `usePomodoroWatcher` detects the newly completed session and opens the memo window
+- This caused the pomodoro timer and memo window to reappear unexpectedly after reopening the app
+- Health reminders had similar persistence but are passive periodic notifications where this behavior is correct
+
+## Solution
+
+- Added `RunEvent::ExitRequested` handler in the Tauri app lifecycle
+- On true app exit (tray → Quit), call `AgentApplication::pause_pomodoro_on_exit()`
+- `pause_pomodoro_on_exit()` calls `pomodoro.pause()` and gracefully ignores "cannot pause unless running" errors
+- The timer is paused and persisted to the database before the app process terminates
+- On restart, the timer remains paused and no auto-completion or memo popup occurs
+- Window close (X button) still only hides the window to tray — timer continues running as before
+
+## Files Changed
+
+- `apps/desktop-tauri/src-tauri/src/lib.rs` — Added `RunEvent::ExitRequested` handler; switched from `.run()` to `.build().run()`
+- `crates/peekoo-agent-app/src/application.rs` — Added `pause_pomodoro_on_exit()` method
+
+## Testing
+
+- `just check` — compiles successfully
+- `cargo test -p peekoo-pomodoro-app -p peekoo-agent-app --lib` — 112 tests passed
+
+## Related
+
+- GitHub Issue: #268
+- Health reminders plugin behavior is unchanged (correctly persists across restarts)

--- a/apps/desktop-tauri/src-tauri/src/lib.rs
+++ b/apps/desktop-tauri/src-tauri/src/lib.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::Duration;
 use tauri::{
-    AppHandle, Emitter, LogicalSize, LogicalUnit, Manager, PixelUnit, State, Window,
+    AppHandle, Emitter, LogicalSize, LogicalUnit, Manager, PixelUnit, RunEvent, State, Window,
     WindowSizeConstraints,
     image::Image,
     menu::MenuBuilder,
@@ -2083,8 +2083,17 @@ pub fn run() {
             plugin_store_update,
             plugin_store_uninstall,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app_handle, event| {
+            if let RunEvent::ExitRequested { .. } = event {
+                if let Some(state) = app_handle.try_state::<AgentState>() {
+                    if let Err(err) = state.app.pause_pomodoro_on_exit() {
+                        tracing::warn!("Failed to pause pomodoro on exit: {err}");
+                    }
+                }
+            }
+        });
 }
 
 fn show_plugin_notification(

--- a/crates/peekoo-agent-app/src/application.rs
+++ b/crates/peekoo-agent-app/src/application.rs
@@ -1121,6 +1121,23 @@ impl AgentApplication {
         self.pomodoro.pause()
     }
 
+    pub fn pause_pomodoro_on_exit(&self) -> Result<(), String> {
+        match self.pomodoro.pause() {
+            Ok(_) => {
+                tracing::info!("Paused pomodoro timer before app exit");
+                Ok(())
+            }
+            Err(err) if err == "cannot pause unless running" => {
+                // Timer was already idle or paused — nothing to do.
+                Ok(())
+            }
+            Err(err) => {
+                tracing::warn!("Failed to pause pomodoro on exit: {err}");
+                Err(err)
+            }
+        }
+    }
+
     pub fn resume_pomodoro(&self) -> Result<PomodoroStatusDto, String> {
         self.pomodoro.resume()
     }


### PR DESCRIPTION
## What changed

- Added `RunEvent::ExitRequested` handler in the Tauri app lifecycle to pause the pomodoro timer before the app process terminates
- Added `pause_pomodoro_on_exit()` method to `AgentApplication` that gracefully handles already-idle timers
- Switched `.run()` to `.build().run()` in `desktop-tauri` to access `RunEvent`

## Release notes

- [x] Add at least one release-note label: `feature`, `fix`, `docs`, `test`, `chore`, `ci`, or `refactor`
- [ ] Use `skip-changelog` if this PR should be excluded from generated release notes

## Verification

- [x] Tests pass locally (`cargo test -p peekoo-pomodoro-app -p peekoo-agent-app --lib`)
- [x] `just check` compiles successfully

Fixes #268