### PR TITLE
fix(pomodoro): prevent memo popup on restart for incomplete sessions

### DIFF
--- a/ai/memories/changelogs/202604221700-fix-pomodoro-memo-popup-on-restart.md
+++ b/ai/memories/changelogs/202604221700-fix-pomodoro-memo-popup-on-restart.md
@@ -1,0 +1,46 @@
+---
+title: "fix: stale pomodoro sessions and old memos triggering popup on restart"
+date: 2026-04-22
+author: opencode
+tags: [fix, pomodoro, memo, app-restart]
+---
+
+## Summary
+
+Fixed two issues causing the Focus Memo popup to appear unexpectedly after app restart, even when the previous focus session was not completed.
+
+## Problem
+
+1. **Stale Running sessions auto-completed on restart**: If a focus session was Running when the app exited (e.g. app crash, or the user ignored the pause-on-exit path), `reconcile_runtime_state()` would detect the expired timer and call `status.complete()`, recording it as **Completed** with `memo_requested=true`. This incremented `completed_focus` and triggered the memo popup.
+
+2. **Old pending memos resurfaced forever**: The frontend's `usePomodoroWatcher` scanned the last 12 history entries on every app launch for any work cycle with `memo_requested=true` and no memo. This meant a focus session completed days ago could still prompt for a memo on every restart.
+
+## Solution
+
+### Backend (`crates/peekoo-pomodoro-app`)
+
+- In `reconcile_runtime_state()`, when a stale `Running` session has expired (`time_remaining_secs == 0`), call `finish()` instead of `complete()`. This records the session as **Cancelled** — no `memo_requested`, no `completed_focus` increment.
+- The scheduler callback `complete_due_session()` remains unchanged; live timer fires still correctly record **Completed**.
+
+### Frontend (`apps/desktop-ui`)
+
+- `hasPendingFocusMemo()` now also checks `entry.outcome === "completed"` as a defensive guard.
+- `findLatestPendingFocusMemo()` now filters to only entries whose `ended_at` is within the last **30 minutes**, preventing ancient pending memos from resurfacing.
+
+### Tests
+
+- Added `stale_running_session_on_init_is_recorded_as_cancelled` in `peekoo-pomodoro-app`: simulates a stale Running session in the DB at startup and verifies it is recorded as Cancelled with `completed_focus` unchanged.
+
+## Files Changed
+
+- `crates/peekoo-pomodoro-app/src/lib.rs` — Stale session handling in `reconcile_runtime_state()`, plus new test
+- `apps/desktop-ui/src/hooks/use-pomodoro-watcher.ts` — Outcome guard and 30-minute recency filter
+
+## Testing
+
+- `cargo test` — 359 tests passed (all suites)
+- `cd apps/desktop-ui && tsc --noEmit` — frontend type-check passed
+
+## Related
+
+- Builds on previous fix: `202604221600-fix-pomodoro-timer-on-app-exit.md` (pause on exit)

--- a/apps/desktop-ui/src/hooks/use-pomodoro-watcher.ts
+++ b/apps/desktop-ui/src/hooks/use-pomodoro-watcher.ts
@@ -11,12 +11,16 @@ import { PANEL_WINDOW_CONFIGS } from "@/types/window";
 function hasPendingFocusMemo(entry: PomodoroHistoryEntry | undefined): boolean {
   if (!entry) return false;
   if (entry.mode !== "work") return false;
+  if (entry.outcome !== "completed") return false;
   if (!entry.memo_requested) return false;
   return !entry.memo || entry.memo.trim().length === 0;
 }
 
 function findLatestPendingFocusMemo(entries: PomodoroHistoryEntry[]): PomodoroHistoryEntry | null {
+  const thirtyMinutesAgo = Date.now() - 30 * 60 * 1000;
   for (const entry of entries) {
+    const endedAt = new Date(entry.ended_at).getTime();
+    if (endedAt < thirtyMinutesAgo) continue;
     if (hasPendingFocusMemo(entry)) {
       return entry;
     }

--- a/crates/peekoo-pomodoro-app/src/lib.rs
+++ b/crates/peekoo-pomodoro-app/src/lib.rs
@@ -434,6 +434,18 @@ impl PomodoroAppService {
             status.last_reset_date = Some(today);
             save_status(&conn, &status)?;
         }
+
+        // If the timer expired while the app was not running, treat it as
+        // cancelled so that memo popups and focus counters stay accurate.
+        if status.state == PomodoroState::Running {
+            let now = now_epoch();
+            status.refresh_time_remaining(now);
+            if status.time_remaining_secs == 0 {
+                let record = status.finish(now).map_err(|err| err.to_string())?;
+                insert_cycle_record(&conn, &record)?;
+                save_status(&conn, &status)?;
+            }
+        }
         drop(conn);
 
         let status = self.refresh_runtime_if_due()?;
@@ -981,5 +993,43 @@ mod tests {
             history[0].task_title.as_deref(),
             Some("Ship memo-task linkage")
         );
+    }
+
+    #[test]
+    fn stale_running_session_on_init_is_recorded_as_cancelled() {
+        let conn = Arc::new(Mutex::new(peekoo_persistence_sqlite::setup_test_db()));
+
+        // Seed a stale Running session whose timer expired while the app was down.
+        let now = now_epoch();
+        let started_at = now - 3600; // started 1 hour ago
+        let expected_fire = now - 1800; // expected to fire 30 min ago
+        {
+            let conn_guard = conn.lock().unwrap();
+            conn_guard
+                .execute(
+                    "UPDATE pomodoro_state SET mode = 'work', state = 'Running', minutes = 25, time_remaining_secs = 1500, started_at_epoch = ?1, expected_fire_at_epoch = ?2, completed_focus = 5, enable_memo = 1, last_reset_date = date('now')",
+                    params![started_at, expected_fire],
+                )
+                .unwrap();
+        }
+
+        let (notifications, _receiver) = NotificationService::new();
+        let service = PomodoroAppService::new(
+            conn,
+            Arc::new(notifications),
+            Arc::new(PeekBadgeService::new()),
+            Arc::new(MoodReactionService::new()),
+        )
+        .expect("service should initialize");
+
+        let status = service.get_status().expect("status should load");
+        assert_eq!(status.state, "Idle");
+        assert_eq!(status.completed_focus, 5); // must NOT increment
+
+        let history = service.history(10).expect("history should load");
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].mode, "work");
+        assert_eq!(history[0].outcome, "cancelled");
+        assert!(!history[0].memo_requested);
     }
 }


### PR DESCRIPTION
## What changed

- **Backend (`peekoo-pomodoro-app`)**: On app restart, stale `Running` sessions whose timer expired while the app was down are now recorded as **Cancelled** instead of **Completed**. This prevents `memo_requested=true` and spurious `completed_focus` increments.
- **Frontend (`desktop-ui`)**: `usePomodoroWatcher` now only prompts for memos from sessions that (a) have `outcome === "completed"` and (b) ended within the last 30 minutes. Old pending memos no longer resurface on every restart.
- Added regression test `stale_running_session_on_init_is_recorded_as_cancelled`.

## Release notes

- [x] `fix`

## Verification

- [x] `cargo test` — 359 tests passed
- [x] `cd apps/desktop-ui && tsc --noEmit` — type-check passed