### PR TITLE
fix(desktop-ui): suppress memo popup during active pomodoro sessions

### DIFF
--- a/apps/desktop-ui/src/hooks/use-pomodoro-watcher.ts
+++ b/apps/desktop-ui/src/hooks/use-pomodoro-watcher.ts
@@ -88,7 +88,9 @@ export function usePomodoroWatcher() {
           lastCompletedRef.current = status.completed_focus;
           isInitialized.current = true;
 
-          if (status.enable_memo) {
+          const isActiveSession =
+            status.state === "Running" || status.state === "Paused";
+          if (status.enable_memo && !isActiveSession) {
             // Covers app restarts or missed transitions where completed_focus delta is not observable.
             await maybePromptPendingMemo(12);
           }
@@ -109,7 +111,11 @@ export function usePomodoroWatcher() {
           lastCompletedRef.current = status.completed_focus;
         } else if (status.enable_memo) {
           // Keep trying while memo remains unsaved, useful when WM blocks first window creation/focus.
-          await maybePromptPendingMemo(12);
+          const isActiveSession =
+            status.state === "Running" || status.state === "Paused";
+          if (!isActiveSession) {
+            await maybePromptPendingMemo(12);
+          }
         }
       } catch {
         // ignore transient errors while pomodoro state is unavailable


### PR DESCRIPTION
## What changed

Prevent the Focus Memo popup from appearing while a pomodoro session is actively Running or Paused. The popup was incorrectly interrupting users during an active focus session when there was an older pending memo in history.

### Changes to `usePomodoroWatcher`

- **Init path**: Only scan for pending memos on app restart if the timer is Idle (not Running/Paused)
- **Retry path**: Only retry opening the memo window during idle states
- **Completion delta path**: Unchanged — memo still pops immediately when a fresh session completes

## Release notes

- [x] `fix`

## Verification

- [x] `cargo test` — 359 tests passed
- [x] `cd apps/desktop-ui && tsc --noEmit` — type-check passed

## Related

- Follow-up to #281 — the previous fix addressed stale sessions and old memos, but missed the case where a memo could popup during an active session.