### PR TITLE
feat(agent-runtime): add Hermes ACP support

### DIFF
--- a/ai/memories/changelogs/202605051200-feat-hermes-acp-runtime.md
+++ b/ai/memories/changelogs/202605051200-feat-hermes-acp-runtime.md
@@ -1,0 +1,17 @@
+## 2026-05-05 12:00: feat: Hermes ACP Runtime
+
+**What changed:**
+- Added PATH-based Hermes Agent ACP runtime detection.
+- Added Available Runtimes guidance with Hermes install docs and install command.
+- Added backend and frontend tests for Hermes detection and guidance visibility.
+
+**Why:**
+- Users can use Hermes as an ACP runtime after installing it locally, without Peekoo managing the Python installation.
+
+**Files affected:**
+- `crates/peekoo-agent-app/src/agent_provider_service.rs`
+- `apps/desktop-ui/src/features/agent-runtimes/AgentProviderPanel.tsx`
+- `apps/desktop-ui/src/features/agent-runtimes/HermesInstallGuidanceCard.tsx`
+- `apps/desktop-ui/src/features/agent-runtimes/hermes-install-guidance.ts`
+- `apps/desktop-ui/src/features/agent-runtimes/hermes-install-guidance.test.ts`
+- `apps/desktop-ui/src/locales/*.json`

--- a/ai/memories/changelogs/202605051200-feat-hermes-acp-runtime.md
+++ b/ai/memories/changelogs/202605051200-feat-hermes-acp-runtime.md
@@ -3,6 +3,7 @@
 **What changed:**
 - Added PATH-based Hermes Agent ACP runtime detection.
 - Added Available Runtimes guidance with Hermes install docs and install command.
+- Added Hermes' official logo for installed runtime and active runtime displays.
 - Added backend and frontend tests for Hermes detection and guidance visibility.
 
 **Why:**
@@ -11,7 +12,10 @@
 **Files affected:**
 - `crates/peekoo-agent-app/src/agent_provider_service.rs`
 - `apps/desktop-ui/src/features/agent-runtimes/AgentProviderPanel.tsx`
+- `apps/desktop-ui/src/features/agent-runtimes/ProviderCard.tsx`
 - `apps/desktop-ui/src/features/agent-runtimes/HermesInstallGuidanceCard.tsx`
 - `apps/desktop-ui/src/features/agent-runtimes/hermes-install-guidance.ts`
 - `apps/desktop-ui/src/features/agent-runtimes/hermes-install-guidance.test.ts`
+- `apps/desktop-ui/src/features/agent-runtimes/runtime-icon-url.ts`
+- `apps/desktop-ui/src/features/agent-runtimes/runtime-icon-url.test.ts`
 - `apps/desktop-ui/src/locales/*.json`

--- a/apps/desktop-ui/src/features/agent-runtimes/AgentProviderPanel.tsx
+++ b/apps/desktop-ui/src/features/agent-runtimes/AgentProviderPanel.tsx
@@ -6,9 +6,11 @@ import { Input } from "@/components/ui/input";
 import { Plus, AlertCircle, RefreshCw, Sparkles, Search, Download } from "lucide-react";
 import { ProviderCard } from "./ProviderCard";
 import { RegistryAgentCard } from "./RegistryAgentCard";
+import { HermesInstallGuidanceCard } from "./HermesInstallGuidanceCard";
 import { InstallProviderDialog } from "./InstallProviderDialog";
 import { ConfigureProviderDialog } from "./ConfigureProviderDialog";
 import { AddCustomRuntimeDialog } from "./AddCustomRuntimeDialog";
+import { shouldShowHermesInstallGuidance } from "./hermes-install-guidance";
 import { useAgentProviders } from "@/hooks/useAgentProviders";
 import { useRegistryAgents } from "@/hooks/useRegistryAgents";
 import { type RuntimeInfo, type InstallationMethod } from "@/types/agent-runtime";
@@ -56,7 +58,8 @@ export function AgentProviderPanel() {
   const [isInstallDialogOpen, setIsInstallDialogOpen] = useState(false);
   const [isConfigureDialogOpen, setIsConfigureDialogOpen] = useState(false);
   const [isAddCustomDialogOpen, setIsAddCustomDialogOpen] = useState(false);
-  const totalAvailableCount = registryAgents.length;
+  const showHermesGuidance = shouldShowHermesInstallGuidance(installedProviders);
+  const totalAvailableCount = registryAgents.length + (showHermesGuidance ? 1 : 0);
 
   // Load providers on mount
   useEffect(() => {
@@ -242,6 +245,7 @@ export function AgentProviderPanel() {
         ) : (
           <>
             <div className="grid gap-4 sm:grid-cols-2">
+              {showHermesGuidance && <HermesInstallGuidanceCard />}
               {registryAgents.map((agent) => (
                 <RegistryAgentCard
                   key={agent.registryId}

--- a/apps/desktop-ui/src/features/agent-runtimes/AgentProviderPanel.tsx
+++ b/apps/desktop-ui/src/features/agent-runtimes/AgentProviderPanel.tsx
@@ -11,6 +11,7 @@ import { InstallProviderDialog } from "./InstallProviderDialog";
 import { ConfigureProviderDialog } from "./ConfigureProviderDialog";
 import { AddCustomRuntimeDialog } from "./AddCustomRuntimeDialog";
 import { shouldShowHermesInstallGuidance } from "./hermes-install-guidance";
+import { getRuntimeIconUrl } from "./runtime-icon-url";
 import { useAgentProviders } from "@/hooks/useAgentProviders";
 import { useRegistryAgents } from "@/hooks/useRegistryAgents";
 import { type RuntimeInfo, type InstallationMethod } from "@/types/agent-runtime";
@@ -142,7 +143,7 @@ export function AgentProviderPanel() {
             <div className="flex items-center gap-3">
               <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-white dark:bg-white/10 overflow-hidden p-1">
                 <img
-                  src={`https://cdn.agentclientprotocol.com/registry/v1/latest/${defaultProvider.providerId}.svg`}
+                  src={getRuntimeIconUrl(defaultProvider.providerId)}
                   alt={defaultProvider.displayName}
                   className="h-8 w-8 object-contain"
                   onError={(e) => {

--- a/apps/desktop-ui/src/features/agent-runtimes/HermesInstallGuidanceCard.tsx
+++ b/apps/desktop-ui/src/features/agent-runtimes/HermesInstallGuidanceCard.tsx
@@ -1,0 +1,52 @@
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { ExternalLink, Terminal } from "lucide-react";
+import { HERMES_INSTALL_COMMAND, HERMES_INSTALL_DOCS_URL } from "./hermes-install-guidance";
+
+export function HermesInstallGuidanceCard() {
+  const { t } = useTranslation();
+
+  return (
+    <Card className="border-dashed border-primary/40 bg-primary/5">
+      <CardHeader className="pb-3">
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-space-deep text-primary">
+            <Terminal className="h-5 w-5" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <CardTitle className="text-sm font-medium text-text-primary">
+              {t("agentRuntimes.hermesGuidance.title")}
+            </CardTitle>
+            <CardDescription className="text-xs text-text-muted">
+              {t("agentRuntimes.hermesGuidance.subtitle")}
+            </CardDescription>
+          </div>
+          <Badge variant="outline" className="shrink-0">
+            PATH
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3 pt-0">
+        <p className="text-xs text-text-muted">
+          {t("agentRuntimes.hermesGuidance.description")}
+        </p>
+        <pre className="overflow-x-auto rounded-md border border-glass-border bg-space-deep p-3 text-xs text-text-secondary">
+          <code>{HERMES_INSTALL_COMMAND}</code>
+        </pre>
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs text-text-muted">
+            {t("agentRuntimes.hermesGuidance.restartHint")}
+          </p>
+          <Button size="sm" variant="outline" asChild>
+            <a href={HERMES_INSTALL_DOCS_URL} target="_blank" rel="noopener noreferrer">
+              <ExternalLink className="mr-1 h-3 w-3" />
+              {t("agentRuntimes.hermesGuidance.docsLink")}
+            </a>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/desktop-ui/src/features/agent-runtimes/ProviderCard.tsx
+++ b/apps/desktop-ui/src/features/agent-runtimes/ProviderCard.tsx
@@ -7,6 +7,7 @@ import {
   type RuntimeInspectionResult,
 } from "@/types/agent-runtime";
 import { getProviderAuthState, getProviderStatusText } from "./provider-auth-state";
+import { getRuntimeIconUrl } from "./runtime-icon-url";
 import { Star, Download, Settings, Trash2, Check, AlertCircle, Loader2, Lock, RefreshCw } from "lucide-react";
 
 interface ProviderCardProps {
@@ -124,7 +125,7 @@ export function ProviderCard({
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-white dark:bg-white/10 overflow-hidden p-1">
             <img
-              src={`https://cdn.agentclientprotocol.com/registry/v1/latest/${provider.providerId}.svg`}
+              src={getRuntimeIconUrl(provider.providerId)}
               alt={provider.displayName}
               className="h-8 w-8 object-contain"
               onError={(e) => {

--- a/apps/desktop-ui/src/features/agent-runtimes/hermes-install-guidance.test.ts
+++ b/apps/desktop-ui/src/features/agent-runtimes/hermes-install-guidance.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { shouldShowHermesInstallGuidance } from "./hermes-install-guidance";
+
+describe("shouldShowHermesInstallGuidance", () => {
+  test("shows guidance when Hermes is not installed", () => {
+    expect(shouldShowHermesInstallGuidance([])).toBe(true);
+  });
+
+  test("hides guidance when Hermes is already installed", () => {
+    expect(
+      shouldShowHermesInstallGuidance([
+        { providerId: "hermes-agent", isInstalled: true },
+      ]),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop-ui/src/features/agent-runtimes/hermes-install-guidance.ts
+++ b/apps/desktop-ui/src/features/agent-runtimes/hermes-install-guidance.ts
@@ -1,0 +1,16 @@
+type RuntimePresence = {
+  providerId: string;
+  isInstalled: boolean;
+};
+
+export const HERMES_INSTALL_DOCS_URL =
+  "https://hermes-agent.nousresearch.com/docs/getting-started/installation";
+
+export const HERMES_INSTALL_COMMAND =
+  "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash";
+
+export function shouldShowHermesInstallGuidance(runtimes: RuntimePresence[]): boolean {
+  return !runtimes.some(
+    (runtime) => runtime.providerId === "hermes-agent" && runtime.isInstalled,
+  );
+}

--- a/apps/desktop-ui/src/features/agent-runtimes/runtime-icon-url.test.ts
+++ b/apps/desktop-ui/src/features/agent-runtimes/runtime-icon-url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { getRuntimeIconUrl } from "./runtime-icon-url";
+
+describe("getRuntimeIconUrl", () => {
+  test("uses the Hermes docs logo for Hermes Agent", () => {
+    expect(getRuntimeIconUrl("hermes-agent")).toBe(
+      "https://hermes-agent.nousresearch.com/docs/img/logo.png",
+    );
+  });
+
+  test("uses ACP registry CDN icons for registry runtimes", () => {
+    expect(getRuntimeIconUrl("opencode")).toBe(
+      "https://cdn.agentclientprotocol.com/registry/v1/latest/opencode.svg",
+    );
+  });
+});

--- a/apps/desktop-ui/src/features/agent-runtimes/runtime-icon-url.ts
+++ b/apps/desktop-ui/src/features/agent-runtimes/runtime-icon-url.ts
@@ -1,0 +1,10 @@
+const RUNTIME_ICON_OVERRIDES: Record<string, string> = {
+  "hermes-agent": "https://hermes-agent.nousresearch.com/docs/img/logo.png",
+};
+
+export function getRuntimeIconUrl(runtimeId: string): string {
+  return (
+    RUNTIME_ICON_OVERRIDES[runtimeId] ??
+    `https://cdn.agentclientprotocol.com/registry/v1/latest/${runtimeId}.svg`
+  );
+}

--- a/apps/desktop-ui/src/locales/en.json
+++ b/apps/desktop-ui/src/locales/en.json
@@ -483,6 +483,13 @@
     "showingRuntimes": "Showing {{count}} runtimes",
     "searchPlaceholder": "Search agents (e.g., Gemini, Cursor, Claude)...",
     "noRuntimesFound": "No runtimes found",
+    "hermesGuidance": {
+      "title": "Hermes Agent",
+      "subtitle": "Install Hermes locally to use it as an ACP runtime.",
+      "description": "Peekoo detects Hermes from your PATH. Install Hermes, then restart Peekoo so the runtime appears in Installed Runtimes.",
+      "restartHint": "Restart Peekoo after installation.",
+      "docsLink": "Installation docs"
+    },
     "loading": "Loading...",
     "loadMore": "Load more agents",
     "default": "Default",

--- a/apps/desktop-ui/src/locales/es.json
+++ b/apps/desktop-ui/src/locales/es.json
@@ -477,6 +477,13 @@
     "showingRuntimes": "Mostrando {{count}} runtimes",
     "searchPlaceholder": "Buscar agentes (ej. Gemini, Cursor, Claude)...",
     "noRuntimesFound": "No se encontraron runtimes",
+    "hermesGuidance": {
+      "title": "Hermes Agent",
+      "subtitle": "Instala Hermes localmente para usarlo como runtime ACP.",
+      "description": "Peekoo detecta Hermes desde tu PATH. Instala Hermes y reinicia Peekoo para que el runtime aparezca en Runtimes instalados.",
+      "restartHint": "Reinicia Peekoo después de instalarlo.",
+      "docsLink": "Documentación de instalación"
+    },
     "loading": "Cargando...",
     "loadMore": "Cargar más agentes",
     "default": "Predeterminado",

--- a/apps/desktop-ui/src/locales/fr.json
+++ b/apps/desktop-ui/src/locales/fr.json
@@ -487,6 +487,13 @@
     "showingRuntimes": "Affichage de {{count}} exécuteurs",
     "searchPlaceholder": "Rechercher des agents (ex. Gemini, Cursor, Claude)...",
     "noRuntimesFound": "Aucun exécuteur trouvé",
+    "hermesGuidance": {
+      "title": "Hermes Agent",
+      "subtitle": "Installez Hermes localement pour l'utiliser comme exécuteur ACP.",
+      "description": "Peekoo détecte Hermes depuis votre PATH. Installez Hermes, puis redémarrez Peekoo pour afficher l'exécuteur dans les exécuteurs installés.",
+      "restartHint": "Redémarrez Peekoo après l'installation.",
+      "docsLink": "Documentation d'installation"
+    },
     "loading": "Chargement...",
     "loadMore": "Charger plus d'agents",
     "default": "Par défaut",

--- a/apps/desktop-ui/src/locales/ja.json
+++ b/apps/desktop-ui/src/locales/ja.json
@@ -477,6 +477,13 @@
     "showingRuntimes": "{{count}} 件のランタイムを表示",
     "searchPlaceholder": "エージェントを検索（例: Gemini, Cursor, Claude）...",
     "noRuntimesFound": "ランタイムが見つかりません",
+    "hermesGuidance": {
+      "title": "Hermes Agent",
+      "subtitle": "Hermes をローカルにインストールすると ACP ランタイムとして使用できます。",
+      "description": "Peekoo は PATH から Hermes を検出します。Hermes をインストールした後、Peekoo を再起動するとインストール済みランタイムに表示されます。",
+      "restartHint": "インストール後に Peekoo を再起動してください。",
+      "docsLink": "インストール手順"
+    },
     "loading": "読み込み中...",
     "loadMore": "さらにエージェントを読み込む",
     "default": "デフォルト",

--- a/apps/desktop-ui/src/locales/zh-TW.json
+++ b/apps/desktop-ui/src/locales/zh-TW.json
@@ -477,6 +477,13 @@
     "showingRuntimes": "顯示 {{count}} 個執行階段",
     "searchPlaceholder": "搜尋智慧體（如 Gemini、Cursor、Claude）...",
     "noRuntimesFound": "未找到執行階段",
+    "hermesGuidance": {
+      "title": "Hermes Agent",
+      "subtitle": "在本機安裝 Hermes 後即可將其用作 ACP 執行階段。",
+      "description": "Peekoo 會從 PATH 偵測 Hermes。安裝 Hermes 後，請重新啟動 Peekoo，讓執行階段顯示在已安裝列表中。",
+      "restartHint": "安裝後請重新啟動 Peekoo。",
+      "docsLink": "安裝文件"
+    },
     "loading": "載入中...",
     "loadMore": "載入更多智慧體",
     "default": "預設",

--- a/apps/desktop-ui/src/locales/zh.json
+++ b/apps/desktop-ui/src/locales/zh.json
@@ -483,6 +483,13 @@
     "showingRuntimes": "显示 {{count}} 个运行时",
     "searchPlaceholder": "搜索智能体（如 Gemini、Cursor、Claude）...",
     "noRuntimesFound": "未找到运行时",
+    "hermesGuidance": {
+      "title": "Hermes Agent",
+      "subtitle": "在本机安装 Hermes 后即可将其用作 ACP 运行时。",
+      "description": "Peekoo 会从 PATH 检测 Hermes。安装 Hermes 后，请重启 Peekoo，让运行时显示在已安装列表中。",
+      "restartHint": "安装后请重启 Peekoo。",
+      "docsLink": "安装文档"
+    },
     "loading": "加载中...",
     "loadMore": "加载更多智能体",
     "default": "默认",

--- a/crates/peekoo-agent-app/src/agent_provider_service.rs
+++ b/crates/peekoo-agent-app/src/agent_provider_service.rs
@@ -161,12 +161,13 @@ pub fn calculate_display_order(registry_id: &str) -> i32 {
         "codex-acp" => 1,
         "claude-acp" => 2,
         "gemini" => 3,
-        "cursor" => 4,
-        "goose" => 5,
-        "kimi" => 6,
-        "qwen-code" => 7,
-        "cline" => 8,
-        "auggie" => 9,
+        "hermes-agent" => 4,
+        "cursor" => 5,
+        "goose" => 6,
+        "kimi" => 7,
+        "qwen-code" => 8,
+        "cline" => 9,
+        "auggie" => 10,
         _ => {
             // Alphabetical order for rest
             100 + registry_id.chars().next().map(|c| c as i32).unwrap_or(127)
@@ -360,6 +361,7 @@ impl AgentProviderService {
             bundled_opencode_path.filter(|path| path.exists() && path.is_file());
 
         Self::seed_installed_opencode(&conn, bundled_opencode_path.as_deref())?;
+        Self::seed_installed_hermes(&conn, command_available("hermes"))?;
 
         // Initialize registry client (may fail if no network/cache, but service still works)
         let registry_client = RegistryClient::new().ok();
@@ -406,6 +408,7 @@ impl AgentProviderService {
             bundled_opencode_path.filter(|path| path.exists() && path.is_file());
 
         Self::seed_installed_opencode(&conn, bundled_opencode_path.as_deref())?;
+        Self::seed_installed_hermes(&conn, command_available("hermes"))?;
 
         // Don't initialize registry client in tests to avoid network calls
         let registry_client = None;
@@ -580,6 +583,48 @@ impl AgentProviderService {
                 if is_bundled { 1i64 } else { 0i64 },
                 now,
             ],
+        )?;
+
+        Ok(())
+    }
+
+    /// Seed Hermes only when its CLI is installed and visible on PATH.
+    fn seed_installed_hermes(conn: &Connection, is_on_path: bool) -> anyhow::Result<()> {
+        let now = chrono::Utc::now().to_rfc3339();
+
+        if !is_on_path {
+            conn.execute(
+                "UPDATE agent_runtimes
+                 SET is_installed = 0,
+                     status = 'not_installed',
+                     status_message = NULL,
+                     updated_at = ?1
+                 WHERE runtime_type = 'hermes-agent'",
+                params![now],
+            )?;
+            return Ok(());
+        }
+
+        conn.execute(
+            "INSERT INTO agent_runtimes (
+                id, runtime_type, display_name, description, command, args_json,
+                installation_method, is_bundled, is_installed, is_default,
+                status, status_message, config_json, registry_id, created_at, updated_at
+            ) VALUES (
+                'provider_hermes-agent', 'hermes-agent', 'Hermes Agent', 'Nous Research Hermes Agent with ACP support',
+                'hermes', '[\"acp\"]',
+                'binary', 0, 1, 0,
+                'ready', NULL, '{}', 'hermes-agent', ?1, ?1
+            )
+            ON CONFLICT(id) DO UPDATE SET
+                command = excluded.command,
+                args_json = excluded.args_json,
+                installation_method = excluded.installation_method,
+                is_installed = excluded.is_installed,
+                status = excluded.status,
+                status_message = excluded.status_message,
+                updated_at = excluded.updated_at",
+            params![now],
         )?;
 
         Ok(())
@@ -2104,6 +2149,7 @@ mod tests {
     fn test_list_providers() {
         let (service, _temp) = create_test_service();
         let opencode_available = command_available("opencode");
+        let hermes_available = command_available("hermes");
 
         let providers = service.list_providers().unwrap();
 
@@ -2116,10 +2162,84 @@ mod tests {
             assert!(opencode.is_installed);
             assert!(opencode.is_default);
             assert!(!opencode.is_bundled);
-        } else {
-            // no rows seeded — DB is empty
+        }
+        if hermes_available {
+            let hermes = providers
+                .iter()
+                .find(|p| p.provider_id == "hermes-agent")
+                .unwrap();
+            assert!(hermes.is_installed);
+            assert!(!hermes.is_bundled);
+        }
+        if !opencode_available && !hermes_available {
+            // no path-discovered rows seeded — DB is empty
             assert!(providers.is_empty());
         }
+    }
+
+    #[test]
+    fn hermes_runtime_is_not_seeded_when_command_is_unavailable() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test_providers.db");
+        let conn = Connection::open(db_path).unwrap();
+        peekoo_persistence_sqlite::run_all_migrations(&conn).unwrap();
+
+        AgentProviderService::seed_installed_hermes(&conn, false).unwrap();
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM agent_runtimes WHERE runtime_type = 'hermes-agent'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn hermes_runtime_is_seeded_with_acp_launch_command_when_available() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test_providers.db");
+        let conn = Connection::open(db_path).unwrap();
+        peekoo_persistence_sqlite::run_all_migrations(&conn).unwrap();
+
+        AgentProviderService::seed_installed_hermes(&conn, true).unwrap();
+
+        let (display_name, command, args_json, status): (String, String, String, String) = conn
+            .query_row(
+                "SELECT display_name, command, args_json, status FROM agent_runtimes WHERE runtime_type = 'hermes-agent'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        let args: Vec<String> = serde_json::from_str(&args_json).unwrap();
+
+        assert_eq!(display_name, "Hermes Agent");
+        assert_eq!(command, "hermes");
+        assert_eq!(args, vec!["acp".to_string()]);
+        assert_eq!(status, "ready");
+    }
+
+    #[test]
+    fn hermes_runtime_is_marked_not_installed_when_command_disappears() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test_providers.db");
+        let conn = Connection::open(db_path).unwrap();
+        peekoo_persistence_sqlite::run_all_migrations(&conn).unwrap();
+
+        AgentProviderService::seed_installed_hermes(&conn, true).unwrap();
+        AgentProviderService::seed_installed_hermes(&conn, false).unwrap();
+
+        let (is_installed, status): (i64, String) = conn
+            .query_row(
+                "SELECT is_installed, status FROM agent_runtimes WHERE runtime_type = 'hermes-agent'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+
+        assert_eq!(is_installed, 0);
+        assert_eq!(status, "not_installed");
     }
 
     #[test]
@@ -2140,6 +2260,7 @@ mod tests {
     fn test_list_runtimes_uses_runtime_table() {
         let (service, _temp) = create_test_service();
         let opencode_available = command_available("opencode");
+        let hermes_available = command_available("hermes");
 
         let runtimes = service.list_runtimes().unwrap();
         let runtime_rows: i64 = service
@@ -2147,13 +2268,24 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM agent_runtimes", [], |row| row.get(0))
             .unwrap();
 
+        let expected_count =
+            (if opencode_available { 1 } else { 0 }) + (if hermes_available { 1 } else { 0 });
+        assert_eq!(runtimes.len(), expected_count as usize);
+        assert_eq!(runtime_rows, expected_count);
+
         if opencode_available {
-            assert_eq!(runtimes.len(), 1);
-            assert_eq!(runtime_rows, 1);
-            assert_eq!(runtimes[0].provider_id, "opencode");
-        } else {
-            assert_eq!(runtimes.len(), 0);
-            assert_eq!(runtime_rows, 0);
+            assert!(
+                runtimes
+                    .iter()
+                    .any(|runtime| runtime.provider_id == "opencode")
+            );
+        }
+        if hermes_available {
+            assert!(
+                runtimes
+                    .iter()
+                    .any(|runtime| runtime.provider_id == "hermes-agent")
+            );
         }
     }
 


### PR DESCRIPTION
## What changed

- Added PATH-based Hermes Agent detection and ACP launch via `hermes acp`
- Added Available Runtimes guidance with Hermes install docs and install command when Hermes is missing from PATH
- Added Hermes logo handling for installed/runtime icon displays
- Added backend/frontend tests and an AI memory changelog

## Release notes

- [x] Add at least one release-note label: `feature`, `fix`, `docs`, `test`, `chore`, `ci`, or `refactor`
- [ ] Use `skip-changelog` if this PR should be excluded from generated release notes

## Verification

- [x] `rtk cargo test -p peekoo-agent-app --lib`
- [x] `bun test src/features/agent-runtimes/hermes-install-guidance.test.ts src/features/agent-runtimes/runtime-icon-url.test.ts`
- [x] `bun run build`