### PR TITLE
feat(agent-runtime): add Hermes ACP support

### DIFF
--- a/apps/desktop-ui/src/features/agent-runtimes/HermesInstallGuidanceCard.tsx
+++ b/apps/desktop-ui/src/features/agent-runtimes/HermesInstallGuidanceCard.tsx
@@ -2,8 +2,12 @@ import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { ExternalLink, Terminal } from "lucide-react";
-import { HERMES_INSTALL_COMMAND, HERMES_INSTALL_DOCS_URL } from "./hermes-install-guidance";
+import { ExternalLink } from "lucide-react";
+import {
+  HERMES_AVAILABLE_RUNTIME_ICON_URL,
+  HERMES_INSTALL_COMMAND,
+  HERMES_INSTALL_DOCS_URL,
+} from "./hermes-install-guidance";
 
 export function HermesInstallGuidanceCard() {
   const { t } = useTranslation();
@@ -13,7 +17,11 @@ export function HermesInstallGuidanceCard() {
       <CardHeader className="pb-3">
         <div className="flex items-start gap-3">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-space-deep text-primary">
-            <Terminal className="h-5 w-5" />
+            <img
+              src={HERMES_AVAILABLE_RUNTIME_ICON_URL}
+              alt={t("agentRuntimes.hermesGuidance.title")}
+              className="h-8 w-8 object-contain"
+            />
           </div>
           <div className="min-w-0 flex-1">
             <CardTitle className="text-sm font-medium text-text-primary">

--- a/apps/desktop-ui/src/features/agent-runtimes/hermes-install-guidance.test.ts
+++ b/apps/desktop-ui/src/features/agent-runtimes/hermes-install-guidance.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { shouldShowHermesInstallGuidance } from "./hermes-install-guidance";
+import {
+  HERMES_AVAILABLE_RUNTIME_ICON_URL,
+  shouldShowHermesInstallGuidance,
+} from "./hermes-install-guidance";
 
 describe("shouldShowHermesInstallGuidance", () => {
   test("shows guidance when Hermes is not installed", () => {
@@ -12,5 +15,11 @@ describe("shouldShowHermesInstallGuidance", () => {
         { providerId: "hermes-agent", isInstalled: true },
       ]),
     ).toBe(false);
+  });
+
+  test("uses the Hermes logo for the available runtime card", () => {
+    expect(HERMES_AVAILABLE_RUNTIME_ICON_URL).toBe(
+      "https://hermes-agent.nousresearch.com/docs/img/logo.png",
+    );
   });
 });

--- a/apps/desktop-ui/src/features/agent-runtimes/hermes-install-guidance.ts
+++ b/apps/desktop-ui/src/features/agent-runtimes/hermes-install-guidance.ts
@@ -9,6 +9,9 @@ export const HERMES_INSTALL_DOCS_URL =
 export const HERMES_INSTALL_COMMAND =
   "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash";
 
+export const HERMES_AVAILABLE_RUNTIME_ICON_URL =
+  "https://hermes-agent.nousresearch.com/docs/img/logo.png";
+
 export function shouldShowHermesInstallGuidance(runtimes: RuntimePresence[]): boolean {
   return !runtimes.some(
     (runtime) => runtime.providerId === "hermes-agent" && runtime.isInstalled,


### PR DESCRIPTION
## What changed

- Added PATH-based Hermes Agent detection and ACP launch via `hermes acp`
- Added Available Runtimes guidance with Hermes install docs and install command when Hermes is missing from PATH
- Added Hermes logo handling for installed, active, and available runtime displays
- Added backend/frontend tests and an AI memory changelog

## Release notes

- [x] Add at least one release-note label: `feature`, `fix`, `docs`, `test`, `chore`, `ci`, or `refactor`
- [ ] Use `skip-changelog` if this PR should be excluded from generated release notes

## Verification

- [x] `rtk cargo test -p peekoo-agent-app --lib`
- [x] `bun test src/features/agent-runtimes/hermes-install-guidance.test.ts src/features/agent-runtimes/runtime-icon-url.test.ts`
- [x] `bun run build`