### PR TITLE
fix(panel): use hide() instead of close() to avoid macOS window errors

### DIFF
--- a/apps/desktop-ui/src/components/panels/PanelShell.tsx
+++ b/apps/desktop-ui/src/components/panels/PanelShell.tsx
@@ -3,7 +3,9 @@ import { X } from "lucide-react";
 import type { MouseEvent, ReactNode } from "react";
 import { emitPetReaction } from "@/lib/pet-events";
 import { motion } from "framer-motion";
+import { closePanelWindow } from "@/hooks/use-panel-windows";
 import { isMacOsPlatform } from "@/lib/window-transparency";
+import type { PanelLabel } from "@/types/window";
 
 interface PanelShellProps {
   title: string;
@@ -39,7 +41,7 @@ export function PanelShell({ title, children }: PanelShellProps) {
   const handleClose = async () => {
     await emitPetReaction("panel-closed");
     const win = getCurrentWindow();
-    await win.close();
+    await closePanelWindow(win.label as PanelLabel);
   };
 
   const handleResizeStart =

--- a/apps/desktop-ui/src/hooks/use-panel-windows-open.test.ts
+++ b/apps/desktop-ui/src/hooks/use-panel-windows-open.test.ts
@@ -1,14 +1,22 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 let existingWindow:
-  | { setFocus?: () => Promise<void>; close?: () => Promise<void> }
+  | {
+      setFocus?: () => Promise<void>;
+      close?: () => Promise<void>;
+      show?: () => Promise<void>;
+      hide?: () => Promise<void>;
+      isVisible?: () => Promise<boolean>;
+    }
   | null = null;
 let focusCount = 0;
 let closeCount = 0;
+let hideCount = 0;
 let createdWindows: Array<{ label: string; options: Record<string, unknown> }> = [];
 let showCount = 0;
 let monitorPointCalls: Array<{ x: number; y: number }> = [];
 let invokeCalls: string[] = [];
+let emittedEvents: Array<{ event: string; payload: unknown }> = [];
 
 const spriteState = {
   scaleFactor: 2,
@@ -36,7 +44,13 @@ class MockWebviewWindow {
   }
 
   static async getByLabel(): Promise<
-    { setFocus?: () => Promise<void>; close?: () => Promise<void> } | null
+    {
+      setFocus?: () => Promise<void>;
+      close?: () => Promise<void>;
+      show?: () => Promise<void>;
+      hide?: () => Promise<void>;
+      isVisible?: () => Promise<boolean>;
+    } | null
   > {
     return existingWindow;
   }
@@ -57,6 +71,13 @@ mock.module("@tauri-apps/api/core", () => ({
     invokeCalls.push(command);
     return null;
   },
+}));
+
+mock.module("@tauri-apps/api/event", () => ({
+  emit: async (event: string, payload: unknown) => {
+    emittedEvents.push({ event, payload });
+  },
+  listen: async () => () => {},
 }));
 
 mock.module("@tauri-apps/api/window", () => ({
@@ -94,10 +115,12 @@ beforeEach(() => {
   existingWindow = null;
   focusCount = 0;
   closeCount = 0;
+  hideCount = 0;
   showCount = 0;
   createdWindows = [];
   monitorPointCalls = [];
   invokeCalls = [];
+  emittedEvents = [];
 
   spriteState.scaleFactor = 2;
   spriteState.outerPosition = { x: 2000, y: 400, logical: { x: 1000, y: 200 } };
@@ -111,6 +134,7 @@ beforeEach(() => {
 describe("openPanelWindow", () => {
   test("focuses an existing panel window instead of creating a new one", async () => {
     existingWindow = {
+      isVisible: async () => true,
       setFocus: async () => {
         focusCount += 1;
       },
@@ -149,14 +173,22 @@ describe("openPanelWindow", () => {
 
   test("saves window state before closing an existing panel", async () => {
     existingWindow = {
-      close: async () => {
-        closeCount += 1;
+      isVisible: async () => true,
+      hide: async () => {
+        hideCount += 1;
       },
     };
 
     await closePanelWindow("panel-chat");
 
     expect(invokeCalls).toEqual(["window_state_save_all"]);
-    expect(closeCount).toBe(1);
+    expect(closeCount).toBe(0);
+    expect(hideCount).toBe(1);
+    expect(emittedEvents).toEqual([
+      {
+        event: "panel-visibility-changed",
+        payload: { label: "panel-chat", isOpen: false },
+      },
+    ]);
   });
 });

--- a/apps/desktop-ui/src/hooks/use-panel-windows.ts
+++ b/apps/desktop-ui/src/hooks/use-panel-windows.ts
@@ -1,5 +1,6 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { emit, listen } from "@tauri-apps/api/event";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { getCurrentWindow, monitorFromPoint } from "@tauri-apps/api/window";
 import type { PanelLabel } from "@/types/window";
@@ -18,6 +19,7 @@ interface PanelWindowState {
 }
 
 export type PanelWindowStates = Record<string, PanelWindowState>;
+export const PANEL_VISIBILITY_CHANGED_EVENT = "panel-visibility-changed";
 
 const INITIAL_STATE: PanelWindowStates = {
   "panel-chat": { isOpen: false },
@@ -111,6 +113,10 @@ export async function openPanelWindow(
 
   const existing = await WebviewWindow.getByLabel(label);
   if (existing) {
+    const isVisible = await existing.isVisible().catch(() => true);
+    if (!isVisible) {
+      await existing.show();
+    }
     await existing.setFocus();
     return existing;
   }
@@ -165,17 +171,45 @@ export async function closePanelWindow(label: PanelLabel): Promise<void> {
 
   const existing = await WebviewWindow.getByLabel(label);
   if (existing) {
-    await existing.close();
+    const isVisible = await existing.isVisible().catch(() => true);
+    if (isVisible) {
+      await existing.hide();
+    }
   }
+
+  await emit(PANEL_VISIBILITY_CHANGED_EVENT, { label, isOpen: false });
 }
 
 export function usePanelWindows() {
   const { plugins: installedPlugins, panels: pluginPanels } = usePlugins();
   const [panels, setPanels] = useState<PanelWindowStates>(INITIAL_STATE);
 
+  useEffect(() => {
+    const unlistenPromise = listen<{ label?: string; isOpen?: boolean }>(
+      PANEL_VISIBILITY_CHANGED_EVENT,
+      (event) => {
+        const label = event.payload?.label;
+        const isOpen = event.payload?.isOpen;
+        if (!label || typeof isOpen !== "boolean") {
+          return;
+        }
+
+        setPanels((prev) => ({ ...prev, [label]: { isOpen } }));
+      },
+    );
+
+    return () => {
+      void unlistenPromise.then((unlisten) => unlisten());
+    };
+  }, []);
+
   const openPanel = useCallback(async (label: PanelLabel) => {
     const existing = await WebviewWindow.getByLabel(label);
     if (existing) {
+      const isVisible = await existing.isVisible().catch(() => true);
+      if (!isVisible) {
+        await existing.show();
+      }
       await existing.setFocus();
       setPanels((prev) => ({ ...prev, [label]: { isOpen: true } }));
       void emitPetReaction("panel-opened");

--- a/apps/desktop-ui/src/hooks/use-pomodoro-watcher.ts
+++ b/apps/desktop-ui/src/hooks/use-pomodoro-watcher.ts
@@ -38,6 +38,10 @@ async function openPomodoroMemoWindow() {
 
   const existing = await WebviewWindow.getByLabel(config.label);
   if (existing) {
+    const isVisible = await existing.isVisible().catch(() => true);
+    if (!isVisible) {
+      await existing.show();
+    }
     await existing.setFocus();
     return;
   }


### PR DESCRIPTION
## Summary
- Changed `closePanelWindow` to use `hide()` instead of `close()` to prevent macOS window errors
- Added `panel-visibility-changed` event to sync window state across components
- Added visibility check in `openPanelWindow` and `openPomodoroMemoWindow` - shows hidden windows before focusing
- Updated tests to reflect new hide/show behavior

Closes #264